### PR TITLE
Improve package loading: validation, warnings, and preprocessPackage hook

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -105,3 +105,12 @@ jobs:
 
       - name: Publish release
         run: npm publish --tag latest --access public
+
+      - name: Create Github Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref }}
+          name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true

--- a/src/fs/index.ts
+++ b/src/fs/index.ts
@@ -2,4 +2,4 @@
  * File system utilities exports
  */
 
-export { ensureDir, fileExists, isFhirPackage } from "./utils.js";
+export { ensureDir, fileExists } from "./utils.js";

--- a/src/fs/utils.ts
+++ b/src/fs/utils.ts
@@ -3,7 +3,6 @@
  */
 
 import * as fs from "node:fs/promises";
-import * as path from "node:path";
 
 export const fileExists = async (filePath: string): Promise<boolean> => {
     try {
@@ -20,25 +19,4 @@ export const ensureDir = async (dirPath: string): Promise<void> => {
     } catch {
         // Ignore errors
     }
-};
-
-export const isFhirPackage = async (dirPath: string): Promise<boolean> => {
-    const indexPath = path.join(dirPath, ".index.json");
-    if (await fileExists(indexPath)) return true;
-
-    const packageJsonPath = path.join(dirPath, "package.json");
-    if (await fileExists(packageJsonPath)) {
-        try {
-            const content = await fs.readFile(packageJsonPath, "utf-8");
-            const packageJson = JSON.parse(content);
-            const withFhirVersion = Array.isArray(packageJson.fhirVersions) && packageJson.fhirVersions.length > 0;
-            if (withFhirVersion) {
-                console.warn(
-                    `Warning: ${packageJson.name} does not have .index.json file. Resources will be scanned from directory (slower).`,
-                );
-                return true;
-            }
-        } catch {}
-    }
-    return false;
 };

--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -27,6 +27,7 @@ import type {
     LocalPackageConfig,
     PackageId,
     PackageInfo,
+    PackageJson,
     Reference,
     Resource,
     SearchParameter,
@@ -514,7 +515,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
         return results;
     };
 
-    const packageJson = async (packageName: string) => {
+    const packageJson = async (packageName: string): Promise<PackageJson> => {
         ensureInitialized();
         const pkg = cache.packages[packageName];
         if (!pkg) throw new Error(`Package ${packageName} not found`);

--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -516,10 +516,9 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
 
     const packageJson = async (packageName: string) => {
         ensureInitialized();
-        const fn = cache.packages[packageName]?.path;
-        if (!fn) throw new Error(`Package ${packageName} not found`);
-        const packageJSON = JSON.parse(await afs.readFile(Path.join(fn, "package.json"), "utf8"));
-        return packageJSON;
+        const pkg = cache.packages[packageName];
+        if (!pkg) throw new Error(`Package ${packageName} not found`);
+        return pkg.packageJson;
     };
 
     const addTgzPackage = async (config: TgzPackageConfig): Promise<PackageId> => {

--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -268,7 +268,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
         } else {
             await installPackages(packageSpecs, npmPackagePath, registry);
             await installConfiguredLocalPackages(npmPackagePath);
-            await scanDirectory(cache, npmPackagePath);
+            await scanDirectory(cache, npmPackagePath, config.preprocessPackage);
             await saveCacheRecordToDisk(cache, workingDir, cacheKey);
         }
 

--- a/src/package.ts
+++ b/src/package.ts
@@ -54,6 +54,83 @@ const ensurePackageJson = async (pwd: string) => {
     }
 };
 
+/**
+ * Parse package reference to extract name (without version)
+ */
+const parsePackageName = (pkg: string): string => {
+    // Handle URLs
+    if (pkg.startsWith("http://") || pkg.startsWith("https://")) {
+        return pkg;
+    }
+    // Handle scoped packages @scope/name@version
+    if (pkg.startsWith("@")) {
+        const match = pkg.match(/^(@[^/]+\/[^@]+)(?:@.*)?$/);
+        return match?.[1] ? match[1] : pkg;
+    }
+    // Handle regular packages name@version
+    const atIndex = pkg.indexOf("@");
+    return atIndex > 0 ? pkg.substring(0, atIndex) : pkg;
+};
+
+/**
+ * Get installed package path in node_modules
+ */
+const getInstalledPackagePath = (packageName: string, pwd: string): string => {
+    const name = parsePackageName(packageName);
+    return Path.join(pwd, "node_modules", name);
+};
+
+/**
+ * Read dependencies from an installed package's package.json
+ */
+const getPackageDependencies = async (packagePath: string): Promise<Record<string, string>> => {
+    const packageJsonPath = Path.join(packagePath, "package.json");
+    if (!(await fileExists(packageJsonPath))) {
+        return {};
+    }
+    try {
+        const content = await afs.readFile(packageJsonPath, "utf8");
+        const pkg = JSON.parse(content) as { dependencies?: Record<string, string> };
+        return pkg.dependencies ?? {};
+    } catch {
+        return {};
+    }
+};
+
+/**
+ * Install a single package using the package manager
+ */
+const installSinglePackage = async (
+    pkg: string,
+    pwd: string,
+    packageManager: PackageManager,
+    registry?: string,
+): Promise<void> => {
+    const safePkg = shellEscape(pkg);
+    const safePwd = shellEscape(pwd);
+    const safeRegistry = registry ? shellEscape(registry) : undefined;
+
+    let cmd: string;
+    const opt: ExecOptions = {
+        maxBuffer: 10 * 1024 * 1024,
+    };
+    if (packageManager === "bun") {
+        cmd = safeRegistry
+            ? `bun add '${safePkg}' --cwd='${safePwd}' --registry='${safeRegistry}'`
+            : `bun add --cwd='${safePwd}' '${safePkg}'`;
+        opt.env = {
+            ...process.env,
+            HOME: pwd, // Prevent reading user's .npmrc
+            NPM_CONFIG_USERCONFIG: "/dev/null", // Extra safety
+        };
+    } else {
+        cmd = safeRegistry
+            ? `cd '${safePwd}' && npm add '${safePkg}' --registry='${safeRegistry}'`
+            : `cd '${safePwd}' && npm add '${safePkg}'`;
+    }
+    await execAsync(cmd, opt);
+};
+
 export const installPackages = async (packages: string[], pwd: string, registry?: string): Promise<void> => {
     await ensureDir(pwd);
     await ensurePackageJson(pwd);
@@ -61,38 +138,53 @@ export const installPackages = async (packages: string[], pwd: string, registry?
     const packageManager = await detectPackageManager();
     if (!packageManager) throw new Error("No package manager found. Please install bun or npm.");
 
+    // Build a map of user-specified package names to their full refs
+    // User-specified versions take precedence over transitive dependency versions
+    const userSpecifiedVersions = new Map<string, string>();
     for (const pkg of packages) {
+        const name = parsePackageName(pkg);
+        userSpecifiedVersions.set(name, pkg);
+    }
+
+    // Track installed packages to avoid circular dependencies
+    const installed = new Set<string>();
+
+    const installWithDependencies = async (pkg: string): Promise<void> => {
+        const packageName = parsePackageName(pkg);
+
+        // Skip if already installed
+        if (installed.has(packageName)) {
+            return;
+        }
+
         if (!isValidPackageRef(pkg)) {
             throw new Error(`Invalid package reference: ${pkg}`);
         }
 
         try {
-            const safePkg = shellEscape(pkg);
-            const safePwd = shellEscape(pwd);
-            const safeRegistry = registry ? shellEscape(registry) : undefined;
+            await installSinglePackage(pkg, pwd, packageManager, registry);
+            installed.add(packageName);
 
-            let cmd: string;
-            const opt: ExecOptions = {
-                maxBuffer: 10 * 1024 * 1024,
-            };
-            if (packageManager === "bun") {
-                cmd = safeRegistry
-                    ? `bun add '${safePkg}' --cwd='${safePwd}' --registry='${safeRegistry}'`
-                    : `bun add --cwd='${safePwd}' '${safePkg}'`;
-                opt.env = {
-                    ...process.env,
-                    HOME: pwd, // Prevent reading user's .npmrc
-                    NPM_CONFIG_USERCONFIG: "/dev/null", // Extra safety
-                };
-            } else {
-                cmd = safeRegistry
-                    ? `cd '${safePwd}' && npm add '${safePkg}' --registry='${safeRegistry}'`
-                    : `cd '${safePwd}' && npm add '${safePkg}'`;
+            // Read dependencies from installed package and install them recursively
+            // This is needed because some registries (like Simplifier) don't expose
+            // dependencies in their npm metadata
+            const packagePath = getInstalledPackagePath(packageName, pwd);
+            const dependencies = await getPackageDependencies(packagePath);
+
+            for (const [depName, depVersion] of Object.entries(dependencies)) {
+                if (!installed.has(depName)) {
+                    // Prefer user-specified version over transitive dependency version
+                    const depRef = userSpecifiedVersions.get(depName) ?? `${depName}@${depVersion}`;
+                    await installWithDependencies(depRef);
+                }
             }
-            await execAsync(cmd, opt);
         } catch (err) {
             console.error(`Failed to install package ${pkg}:`, err);
             throw err;
         }
+    };
+
+    for (const pkg of packages) {
+        await installWithDependencies(pkg);
     }
 };

--- a/src/scanner/directory.ts
+++ b/src/scanner/directory.ts
@@ -1,49 +1,35 @@
 /**
- * Directory scanning functionality
+ * npm package loading into cache
  */
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ExtendedCache } from "../cache.js";
-import { isFhirPackage } from "../fs/index.js";
-import { scanPackage } from "./package.js";
+import { loadPackage } from "./package.js";
 
-export const scanDirectory = async (cache: ExtendedCache, pwd: string): Promise<void> => {
+export const loadPackagesIntoCache = async (cache: ExtendedCache, pwd: string): Promise<void> => {
     const nodeModulesPath = path.join(pwd, "node_modules");
     const entries = await fs.readdir(nodeModulesPath, { withFileTypes: true });
-    const nonFhirPackages: string[] = [];
+    const warnings: string[] = [];
 
     for (const entry of entries) {
         if (!entry.isDirectory()) continue;
-
-        const fullPath = path.join(entry.parentPath, entry.name);
+        const packagePath = path.join(entry.parentPath, entry.name);
 
         if (entry.name.startsWith("@")) {
-            const scopedEntries = await fs.readdir(fullPath, {
-                withFileTypes: true,
-            });
+            const scopedEntries = await fs.readdir(packagePath, { withFileTypes: true });
             for (const scopedEntry of scopedEntries) {
                 if (!scopedEntry.isDirectory()) continue;
-
-                const scopedPath = path.join(fullPath, scopedEntry.name);
-                const packageName = `${entry.name}/${scopedEntry.name}`;
-
-                if (await isFhirPackage(scopedPath)) {
-                    await scanPackage(scopedPath, cache);
-                } else {
-                    nonFhirPackages.push(packageName);
-                }
+                const w = await loadPackage(path.join(packagePath, scopedEntry.name), cache);
+                if (w) warnings.push(w);
             }
-        } else if (await isFhirPackage(fullPath)) {
-            await scanPackage(fullPath, cache);
         } else {
-            nonFhirPackages.push(entry.name);
+            const w = await loadPackage(packagePath, cache);
+            if (w) warnings.push(w);
         }
     }
 
-    if (nonFhirPackages.length > 0) {
-        console.warn(
-            `Warning: The following packages appear to be FHIR-related but are missing FHIR metadata (.index.json or fhirVersions in package.json):\n  - ${nonFhirPackages.join("\n  - ")}`,
-        );
+    if (warnings.length > 0) {
+        console.warn(`Warnings:\n${warnings.map((w) => `  - ${w}`).join("\n")}`);
     }
 };

--- a/src/scanner/directory.ts
+++ b/src/scanner/directory.ts
@@ -5,9 +5,14 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ExtendedCache } from "../cache.js";
+import type { PreprocessPackageContext } from "../types/index.js";
 import { loadPackage } from "./package.js";
 
-export const loadPackagesIntoCache = async (cache: ExtendedCache, pwd: string): Promise<void> => {
+export const loadPackagesIntoCache = async (
+    cache: ExtendedCache,
+    pwd: string,
+    preprocessPackage?: (context: PreprocessPackageContext) => PreprocessPackageContext,
+): Promise<void> => {
     const nodeModulesPath = path.join(pwd, "node_modules");
     const entries = await fs.readdir(nodeModulesPath, { withFileTypes: true });
     const warnings: string[] = [];
@@ -20,11 +25,11 @@ export const loadPackagesIntoCache = async (cache: ExtendedCache, pwd: string): 
             const scopedEntries = await fs.readdir(packagePath, { withFileTypes: true });
             for (const scopedEntry of scopedEntries) {
                 if (!scopedEntry.isDirectory()) continue;
-                const w = await loadPackage(path.join(packagePath, scopedEntry.name), cache);
+                const w = await loadPackage(path.join(packagePath, scopedEntry.name), cache, preprocessPackage);
                 if (w) warnings.push(w);
             }
         } else {
-            const w = await loadPackage(packagePath, cache);
+            const w = await loadPackage(packagePath, cache, preprocessPackage);
             if (w) warnings.push(w);
         }
     }

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -2,7 +2,7 @@
  * Scanner module exports
  */
 
-export { scanDirectory } from "./directory.js";
-export { scanPackage } from "./package.js";
+export { loadPackagesIntoCache as scanDirectory } from "./directory.js";
+export { loadPackage } from "./package.js";
 export { isValidFileEntry, isValidIndexFile, parseIndex } from "./parser.js";
 export { processIndex } from "./processor.js";

--- a/src/scanner/package.ts
+++ b/src/scanner/package.ts
@@ -113,7 +113,7 @@ export const loadPackage = async (
         path: packagePath,
         canonical: packageJson.canonical,
         fhirVersions: packageJson.fhirVersions,
-        packageJson: packageJson as unknown as Record<string, unknown>,
+        packageJson,
     };
 
     const hasIndex = await fileExists(path.join(packagePath, ".index.json"));

--- a/src/scanner/package.ts
+++ b/src/scanner/package.ts
@@ -113,6 +113,7 @@ export const loadPackage = async (
         path: packagePath,
         canonical: packageJson.canonical,
         fhirVersions: packageJson.fhirVersions,
+        packageJson: packageJson as unknown as Record<string, unknown>,
     };
 
     const hasIndex = await fileExists(path.join(packagePath, ".index.json"));

--- a/src/scanner/package.ts
+++ b/src/scanner/package.ts
@@ -13,7 +13,8 @@ const scanDirectoryForResources = async (
     dirPath: string,
     packageJson: PackageJson,
     cache: ExtendedCache,
-): Promise<void> => {
+): Promise<number> => {
+    let count = 0;
     try {
         const entries = await fs.readdir(dirPath, { withFileTypes: true });
 
@@ -27,11 +28,7 @@ const scanDirectoryForResources = async (
                 const content = await fs.readFile(filePath, "utf-8");
                 const resource = JSON.parse(content);
 
-                // Check if it's a FHIR resource with resourceType
-                if (!resource.resourceType) continue;
-
-                const url = resource.url;
-                if (!url) continue; // Only index resources with canonical URLs
+                if (!resource.resourceType || !resource.url) continue;
 
                 const id = cache.referenceManager.generateId({
                     packageName: packageJson.name,
@@ -44,15 +41,15 @@ const scanDirectoryForResources = async (
                     packageVersion: packageJson.version,
                     filePath,
                     resourceType: resource.resourceType,
-                    url,
+                    url: resource.url,
                     version: resource.version,
                 });
 
                 const indexEntry: IndexEntry = {
                     id,
                     resourceType: resource.resourceType,
-                    indexVersion: 0, // No index version for manually scanned resources
-                    url,
+                    indexVersion: 0,
+                    url: resource.url,
                     version: resource.version,
                     kind: resource.kind,
                     type: resource.type,
@@ -62,10 +59,11 @@ const scanDirectoryForResources = async (
                     },
                 };
 
-                if (!cache.entries[url]) {
-                    cache.entries[url] = [];
+                if (!cache.entries[resource.url]) {
+                    cache.entries[resource.url] = [];
                 }
-                cache.entries[url]?.push(indexEntry);
+                cache.entries[resource.url]?.push(indexEntry);
+                count++;
             } catch {
                 // Skip files that can't be parsed
             }
@@ -73,36 +71,70 @@ const scanDirectoryForResources = async (
     } catch {
         // Silently ignore directory scan errors
     }
+    return count;
 };
 
-export const scanPackage = async (packagePath: string, cache: ExtendedCache): Promise<void> => {
+const CORE_PACKAGE_PATTERN = /^hl7\.fhir\.r\d+\.core$/;
+
+const isCorePackage = (name: string): boolean => CORE_PACKAGE_PATTERN.test(name);
+
+const hasCorePackageDependency = (dependencies: Record<string, string> | undefined): boolean => {
+    if (!dependencies) return false;
+    return Object.keys(dependencies).some(isCorePackage);
+};
+
+/**
+ * Load a package into cache. Always registers. Scans resources if possible.
+ * Returns a warning string if there's something to warn about, undefined otherwise.
+ */
+export const loadPackage = async (packagePath: string, cache: ExtendedCache): Promise<string | undefined> => {
+    const packageJsonPath = path.join(packagePath, "package.json");
+    if (!(await fileExists(packageJsonPath))) return undefined;
+
+    let packageJson: PackageJson;
     try {
-        const packageJsonPath = path.join(packagePath, "package.json");
-        const packageJsonContent = await fs.readFile(packageJsonPath, "utf-8");
-        const packageJson: PackageJson = JSON.parse(packageJsonContent);
+        const content = await fs.readFile(packageJsonPath, "utf-8");
+        packageJson = JSON.parse(content);
+    } catch {
+        return undefined;
+    }
 
-        const packageInfo: PackageInfo = {
-            id: { name: packageJson.name, version: packageJson.version },
-            path: packagePath,
-            canonical: packageJson.canonical,
-            fhirVersions: packageJson.fhirVersions,
-        };
-        cache.packages[packageJson.name] = packageInfo;
+    // Always register
+    cache.packages[packageJson.name] = {
+        id: { name: packageJson.name, version: packageJson.version },
+        path: packagePath,
+        canonical: packageJson.canonical,
+        fhirVersions: packageJson.fhirVersions,
+    };
 
-        const indexPath = path.join(packagePath, ".index.json");
-        const hasIndex = await fileExists(indexPath);
+    const hasIndex = await fileExists(path.join(packagePath, ".index.json"));
+    const hasFhirVersions = Array.isArray(packageJson.fhirVersions) && packageJson.fhirVersions.length > 0;
+    const hasCoreDep = isCorePackage(packageJson.name) || hasCorePackageDependency(packageJson.dependencies);
 
-        if (hasIndex) {
-            await processIndex(packagePath, packageJson, cache);
-        } else {
-            await scanDirectoryForResources(packagePath, packageJson, cache);
-        }
-
+    let resourceCount = 0;
+    if (hasIndex) {
+        await processIndex(packagePath, packageJson, cache);
         const examplesPath = path.join(packagePath, "examples");
         if (await fileExists(path.join(examplesPath, ".index.json"))) {
             await processIndex(examplesPath, packageJson, cache);
         }
-    } catch {
-        // Silently ignore package scan errors
+        resourceCount = 1; // Has index, assume it has resources
+    } else {
+        resourceCount = await scanDirectoryForResources(packagePath, packageJson, cache);
+        if (resourceCount > 0) {
+            console.warn(`Warning: index generated for ${packageJson.name} (${resourceCount} resources)`);
+        }
     }
+
+    // No resources = not a FHIR package, no warning needed
+    if (resourceCount === 0) return undefined;
+
+    // Collect issues
+    const issues: string[] = [];
+    if (!hasIndex) issues.push("no .index.json");
+    if (!hasFhirVersions) issues.push("no fhirVersions");
+    if (!hasCoreDep) issues.push("no core dependency");
+
+    if (issues.length === 0) return undefined;
+    return `${packageJson.name}: ${issues.join(", ")}`;
 };

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -102,6 +102,7 @@ export interface PackageInfo {
     path: string;
     canonical?: string;
     fhirVersions?: string[];
+    packageJson?: Record<string, unknown>;
 }
 
 export interface CanonicalManager {

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -97,13 +97,24 @@ export interface LocalPackageConfig {
     dependencies?: string[];
 }
 
-export interface PackageInfo {
+export type PackageJson = {
+    name: string;
+    version: string;
+    /** Optional: not all packages declare FHIR version (e.g., hl7.fhir.r4.core lacks it) */
+    fhirVersions?: string[];
+    type?: string;
+    canonical?: string;
+    dependencies?: Record<string, string>;
+    [key: string]: unknown;
+};
+
+export type PackageInfo = {
     id: PackageId;
     path: string;
     canonical?: string;
     fhirVersions?: string[];
-    packageJson?: Record<string, unknown>;
-}
+    packageJson: PackageJson;
+};
 
 export interface CanonicalManager {
     init(): Promise<Record<string, PackageId>>;
@@ -154,5 +165,5 @@ export interface CanonicalManager {
         },
     ): Promise<IndexEntry[]>;
     getSearchParametersForResource(resourceType: string): Promise<SearchParameter[]>;
-    packageJson(packageName: string): Promise<unknown>;
+    packageJson(packageName: string): Promise<PackageJson>;
 }

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -68,11 +68,17 @@ export interface SourceContext {
     path?: string;
 }
 
+export type PreprocessPackageContext = {
+    packageJson: Record<string, unknown>;
+};
+
 export interface Config {
     packages: string[];
     workingDir: string;
     registry?: string;
     dropCache?: boolean;
+    /** Hook to preprocess package.json before loading. Can modify and return the data. */
+    preprocessPackage?: (context: PreprocessPackageContext) => PreprocessPackageContext;
 }
 
 export interface TgzPackageConfig {

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -18,15 +18,6 @@ export interface IndexFileEntry {
     type?: string;
 }
 
-export interface PackageJson {
-    name: string;
-    version: string;
-    fhirVersions?: string[];
-    type?: string;
-    canonical?: string;
-    dependencies?: Record<string, string>;
-}
-
 export interface ReferenceMetadata {
     packageName: string;
     packageVersion: string;

--- a/test/unit/cache/cache.test.ts
+++ b/test/unit/cache/cache.test.ts
@@ -65,6 +65,7 @@ describe("Cache Module", () => {
             cache.packages["test.package"] = {
                 id: { name: "test.package", version: "1.0.0" },
                 path: "/path/to/package",
+                packageJson: { name: "test.package", version: "1.0.0" },
             };
 
             const metadata: ReferenceMetadata = {
@@ -133,6 +134,7 @@ describe("Cache Module", () => {
                     "test.package": {
                         id: { name: "test.package", version: "1.0.0" },
                         path: "/path/to/package",
+                        packageJson: { name: "test.package", version: "1.0.0" },
                     },
                 },
                 references: {

--- a/test/unit/fs/fs.test.ts
+++ b/test/unit/fs/fs.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { ensureDir, fileExists, isFhirPackage } from "../../../src/fs";
+import { ensureDir, fileExists } from "../../../src/fs";
 
 describe("File System Utilities", () => {
     let tempDir: string;
@@ -93,47 +93,6 @@ describe("File System Utilities", () => {
 
             const stats = await fs.stat(filePath);
             expect(stats.isFile()).toBe(true);
-        });
-    });
-
-    describe("isFhirPackage", () => {
-        test("should return true for FHIR package directory", async () => {
-            const packageDir = path.join(tempDir, "fhir-package");
-            await fs.mkdir(packageDir);
-            await fs.writeFile(path.join(packageDir, ".index.json"), "{}");
-
-            const isFhir = await isFhirPackage(packageDir);
-            expect(isFhir).toBe(true);
-        });
-
-        test("should return false for non-FHIR package directory", async () => {
-            const regularDir = path.join(tempDir, "regular-dir");
-            await fs.mkdir(regularDir);
-
-            const isFhir = await isFhirPackage(regularDir);
-            expect(isFhir).toBe(false);
-        });
-
-        test("should return false for directory with other files", async () => {
-            const dir = path.join(tempDir, "other-package");
-            await fs.mkdir(dir);
-            await fs.writeFile(path.join(dir, "package.json"), "{}");
-            await fs.writeFile(path.join(dir, "index.json"), "{}"); // Note: no dot prefix
-
-            const isFhir = await isFhirPackage(dir);
-            expect(isFhir).toBe(false);
-        });
-
-        test("should return false for non-existent directory", async () => {
-            const nonExistent = path.join(tempDir, "does-not-exist");
-
-            const isFhir = await isFhirPackage(nonExistent);
-            expect(isFhir).toBe(false);
-        });
-
-        test("should handle invalid paths gracefully", async () => {
-            const isFhir = await isFhirPackage("");
-            expect(isFhir).toBe(false);
         });
     });
 });

--- a/test/unit/scanner/scanner.test.ts
+++ b/test/unit/scanner/scanner.test.ts
@@ -6,10 +6,10 @@ import { createCacheRecord } from "../../../src/cache";
 import {
     isValidFileEntry,
     isValidIndexFile,
+    loadPackage,
     parseIndex,
     processIndex,
     scanDirectory,
-    scanPackage,
 } from "../../../src/scanner";
 import type { PackageJson } from "../../../src/types";
 
@@ -289,7 +289,7 @@ describe("Scanner Module", () => {
         });
     });
 
-    describe("scanPackage", () => {
+    describe("loadPackage", () => {
         test("should scan a complete FHIR package", async () => {
             const cache = createCacheRecord();
             const packagePath = path.join(tempDir, "test-package");
@@ -320,7 +320,7 @@ describe("Scanner Module", () => {
 
             await fs.writeFile(path.join(packagePath, ".index.json"), JSON.stringify(indexContent));
 
-            await scanPackage(packagePath, cache);
+            await loadPackage(packagePath, cache);
 
             // Check package info
             expect(cache.packages["hl7.fhir.test"]).toBeDefined();
@@ -376,7 +376,7 @@ describe("Scanner Module", () => {
                 }),
             );
 
-            await scanPackage(packagePath, cache);
+            await loadPackage(packagePath, cache);
 
             expect(cache.entries["http://example.com/Profile"]).toHaveLength(1);
             expect(cache.entries["http://example.com/Patient/example"]).toHaveLength(1);
@@ -387,9 +387,102 @@ describe("Scanner Module", () => {
             const packagePath = path.join(tempDir, "invalid-package");
 
             // Should not throw
-            await scanPackage(packagePath, cache);
+            await loadPackage(packagePath, cache);
 
             expect(Object.keys(cache.packages)).toHaveLength(0);
+        });
+    });
+
+    describe("loadPackage with preprocessPackage hook", () => {
+        test("should apply preprocessPackage hook to modify package.json in memory", async () => {
+            const cache = createCacheRecord();
+            const packagePath = path.join(tempDir, "test-package");
+            await fs.mkdir(packagePath, { recursive: true });
+
+            // Create package.json with a typo in name
+            await fs.writeFile(
+                path.join(packagePath, "package.json"),
+                JSON.stringify({
+                    name: "test.packge", // typo
+                    version: "1.0.0",
+                    fhirVersions: ["4.0.1"],
+                    dependencies: { "hl7.fhir.r4.core": "4.0.1" },
+                }),
+            );
+
+            // Create .index.json
+            await fs.writeFile(
+                path.join(packagePath, ".index.json"),
+                JSON.stringify({
+                    "index-version": 1,
+                    files: [
+                        {
+                            filename: "Patient.json",
+                            resourceType: "StructureDefinition",
+                            id: "Patient",
+                            url: "http://example.com/Patient",
+                        },
+                    ],
+                }),
+            );
+
+            // Hook that fixes the typo
+            const preprocessPackage = ({ packageJson }: { packageJson: Record<string, unknown> }) => {
+                if (packageJson.name === "test.packge") {
+                    return { packageJson: { ...packageJson, name: "test.package" } };
+                }
+                return { packageJson };
+            };
+
+            await loadPackage(packagePath, cache, preprocessPackage);
+
+            // Check that cache uses the fixed name
+            expect(cache.packages["test.package"]).toBeDefined();
+            expect(cache.packages["test.packge"]).toBeUndefined();
+            expect(cache.packages["test.package"]?.id.name).toBe("test.package");
+        });
+
+        test("should not modify original file on disk", async () => {
+            const cache = createCacheRecord();
+            const packagePath = path.join(tempDir, "test-package");
+            await fs.mkdir(packagePath, { recursive: true });
+
+            const originalContent = {
+                name: "original.name",
+                version: "1.0.0",
+                fhirVersions: ["4.0.1"],
+                dependencies: { "hl7.fhir.r4.core": "4.0.1" },
+            };
+
+            await fs.writeFile(path.join(packagePath, "package.json"), JSON.stringify(originalContent));
+
+            await fs.writeFile(
+                path.join(packagePath, ".index.json"),
+                JSON.stringify({
+                    "index-version": 1,
+                    files: [
+                        {
+                            filename: "Resource.json",
+                            resourceType: "StructureDefinition",
+                            id: "Resource",
+                            url: "http://example.com/Resource",
+                        },
+                    ],
+                }),
+            );
+
+            const preprocessPackage = ({ packageJson }: { packageJson: Record<string, unknown> }) => {
+                return { packageJson: { ...packageJson, name: "modified.name" } };
+            };
+
+            await loadPackage(packagePath, cache, preprocessPackage);
+
+            // Cache should have modified name
+            expect(cache.packages["modified.name"]).toBeDefined();
+
+            // File on disk should remain unchanged
+            const fileContent = JSON.parse(await fs.readFile(path.join(packagePath, "package.json"), "utf-8"));
+            expect(fileContent.name).toBe("original.name");
         });
     });
 
@@ -432,7 +525,7 @@ describe("Scanner Module", () => {
             await scanDirectory(cache, tempDir);
 
             expect(cache.packages["fhir.package1"]).toBeDefined();
-            expect(cache.packages["regular.package"]).toBeUndefined();
+            expect(cache.packages["regular.package"]).toBeDefined(); // All packages are registered now
             expect(cache.entries["http://example.com/Resource1"]).toHaveLength(1);
         });
 

--- a/test/unit/scanner/scanner.test.ts
+++ b/test/unit/scanner/scanner.test.ts
@@ -440,6 +440,8 @@ describe("Scanner Module", () => {
             expect(cache.packages["test.package"]).toBeDefined();
             expect(cache.packages["test.packge"]).toBeUndefined();
             expect(cache.packages["test.package"]?.id.name).toBe("test.package");
+            // Check that packageJson in cache contains preprocessed data
+            expect(cache.packages["test.package"]?.packageJson?.name).toBe("test.package");
         });
 
         test("should not modify original file on disk", async () => {
@@ -479,6 +481,8 @@ describe("Scanner Module", () => {
 
             // Cache should have modified name
             expect(cache.packages["modified.name"]).toBeDefined();
+            // packageJson in cache should have preprocessed data
+            expect(cache.packages["modified.name"]?.packageJson?.name).toBe("modified.name");
 
             // File on disk should remain unchanged
             const fileContent = JSON.parse(await fs.readFile(path.join(packagePath, "package.json"), "utf-8"));


### PR DESCRIPTION
- **User-specified versions take precedence**: When installing packages, user-specified versions now override transitive dependency versions
- **Register all packages in cache**: All packages (including non-FHIR transitive dependencies) are now registered, enabling `packageJson()` access for any installed package
- **Package validation warnings**: Show warnings for FHIR packages missing:
  - `.index.json` file
  - `fhirVersions` in package.json
  - Core FHIR package dependency (e.g., `hl7.fhir.r4.core`)
- **Index generation warning**: Separate warning when index is generated via directory scanning for packages without `.index.json`
- **preprocessPackage hook**: New Config option to transform package.json data in memory before loading (files on disk unchanged)