### PR TITLE
Extend preprocessPackage hook to support resource preprocessing

### DIFF
--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -377,13 +377,26 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
 
         try {
             const content = await afs.readFile(metadata.filePath, "utf-8");
-            const resource = JSON.parse(content);
+            const parsed = JSON.parse(content);
 
-            return {
-                ...resource,
+            let resource: Resource = {
+                ...parsed,
                 id: reference.id,
                 resourceType: reference.resourceType,
             };
+
+            if (config.preprocessPackage) {
+                const result = config.preprocessPackage({
+                    kind: "resource",
+                    resource,
+                    package: { name: metadata.packageName, version: metadata.packageVersion },
+                });
+                if (result.kind === "resource") {
+                    resource = result.resource;
+                }
+            }
+
+            return resource;
         } catch (err) {
             throw new Error(`Failed to read resource: ${err}`);
         }

--- a/src/scanner/directory.ts
+++ b/src/scanner/directory.ts
@@ -5,13 +5,13 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ExtendedCache } from "../cache.js";
-import type { PreprocessPackageContext } from "../types/index.js";
+import type { PreprocessContext } from "../types/index.js";
 import { loadPackage } from "./package.js";
 
 export const loadPackagesIntoCache = async (
     cache: ExtendedCache,
     pwd: string,
-    preprocessPackage?: (context: PreprocessPackageContext) => PreprocessPackageContext,
+    preprocessPackage?: (context: PreprocessContext) => PreprocessContext,
 ): Promise<void> => {
     const nodeModulesPath = path.join(pwd, "node_modules");
     const entries = await fs.readdir(nodeModulesPath, { withFileTypes: true });

--- a/src/scanner/package.ts
+++ b/src/scanner/package.ts
@@ -6,7 +6,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ExtendedCache } from "../cache.js";
 import { fileExists } from "../fs/index.js";
-import type { IndexEntry, PackageJson, PreprocessPackageContext } from "../types/index.js";
+import type { IndexEntry, PackageJson, PreprocessContext } from "../types/index.js";
 import { processIndex } from "./processor.js";
 
 const scanDirectoryForResources = async (
@@ -90,7 +90,7 @@ const hasCorePackageDependency = (dependencies: Record<string, string> | undefin
 export const loadPackage = async (
     packagePath: string,
     cache: ExtendedCache,
-    preprocessPackage?: (context: PreprocessPackageContext) => PreprocessPackageContext,
+    preprocessPackage?: (context: PreprocessContext) => PreprocessContext,
 ): Promise<string | undefined> => {
     const packageJsonPath = path.join(packagePath, "package.json");
     if (!(await fileExists(packageJsonPath))) return undefined;
@@ -100,7 +100,12 @@ export const loadPackage = async (
         const content = await fs.readFile(packageJsonPath, "utf-8");
         let parsed = JSON.parse(content);
         if (preprocessPackage) {
-            parsed = preprocessPackage({ packageJson: parsed }).packageJson;
+            const result = preprocessPackage({
+                kind: "package",
+                packageJson: parsed,
+                package: { name: parsed.name, version: parsed.version },
+            });
+            if (result.kind === "package") parsed = result.packageJson;
         }
         packageJson = parsed as PackageJson;
     } catch {

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -68,17 +68,29 @@ export interface SourceContext {
     path?: string;
 }
 
-export type PreprocessPackageContext = {
+export type PreprocessBaseContext = {
+    package: PackageId;
+};
+
+export type PreprocessPackageContext = PreprocessBaseContext & {
+    kind: "package";
     packageJson: Record<string, unknown>;
 };
+
+export type PreprocessResourceContext = PreprocessBaseContext & {
+    kind: "resource";
+    resource: Resource;
+};
+
+export type PreprocessContext = PreprocessPackageContext | PreprocessResourceContext;
 
 export interface Config {
     packages: string[];
     workingDir: string;
     registry?: string;
     dropCache?: boolean;
-    /** Hook to preprocess package.json before loading. Can modify and return the data. */
-    preprocessPackage?: (context: PreprocessPackageContext) => PreprocessPackageContext;
+    /** Hook to preprocess packages and resources. Receives a discriminated union with `kind` field. */
+    preprocessPackage?: (context: PreprocessContext) => PreprocessContext;
 }
 
 export interface TgzPackageConfig {

--- a/test/unit/manager/preprocess-resource.test.ts
+++ b/test/unit/manager/preprocess-resource.test.ts
@@ -1,0 +1,189 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { CanonicalManager } from "../../../src";
+import type { PreprocessContext } from "../../../src/types";
+
+const TEST_CANONICAL = "http://example.org/fhir/StructureDefinition/TestProfile";
+
+describe("preprocessPackage with kind: resource", () => {
+	const tmpRoot = path.join(process.cwd(), "tmp", "preprocess-resource-tests");
+	const workingDir = path.join(tmpRoot, "working-dir");
+	const localPackagePath = path.join(tmpRoot, "local-package");
+	const resourceFilePath = path.join(localPackagePath, "StructureDefinition-TestProfile.json");
+
+	const originalResource = {
+		resourceType: "StructureDefinition",
+		id: "TestProfile",
+		url: TEST_CANONICAL,
+		name: "TestProfile",
+		description: "Original description",
+	};
+
+	beforeAll(async () => {
+		await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+		await fs.mkdir(localPackagePath, { recursive: true });
+
+		await fs.writeFile(
+			path.join(localPackagePath, "package.json"),
+			JSON.stringify({ name: "test.package", version: "1.0.0" }),
+		);
+		await fs.writeFile(
+			path.join(localPackagePath, ".index.json"),
+			JSON.stringify({
+				"index-version": 1,
+				files: [
+					{
+						filename: "StructureDefinition-TestProfile.json",
+						resourceType: "StructureDefinition",
+						id: "TestProfile",
+						url: TEST_CANONICAL,
+						kind: "resource",
+						type: "StructureDefinition",
+					},
+				],
+			}),
+		);
+		await fs.writeFile(resourceFilePath, JSON.stringify(originalResource));
+	});
+
+	afterAll(async () => {
+		await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+	});
+
+	test("should modify resources returned by read()", async () => {
+		const manager = CanonicalManager({
+			packages: [],
+			workingDir,
+			preprocessPackage: (ctx: PreprocessContext): PreprocessContext => {
+				if (ctx.kind !== "resource") return ctx;
+				return {
+					...ctx,
+					resource: { ...ctx.resource, description: "Modified description" },
+				};
+			},
+		});
+
+		await manager.addLocalPackage({
+			name: "test.package",
+			version: "1.0.0",
+			path: localPackagePath,
+		});
+		await manager.init();
+
+		const resource = await manager.resolve(TEST_CANONICAL);
+		expect(resource.description).toBe("Modified description");
+		await manager.destroy();
+	});
+
+	test("should modify resources returned by search()", async () => {
+		const manager = CanonicalManager({
+			packages: [],
+			workingDir: path.join(tmpRoot, "working-dir-search"),
+			preprocessPackage: (ctx: PreprocessContext): PreprocessContext => {
+				if (ctx.kind !== "resource") return ctx;
+				return {
+					...ctx,
+					resource: { ...ctx.resource, description: "Search modified" },
+				};
+			},
+		});
+
+		await manager.addLocalPackage({
+			name: "test.package",
+			version: "1.0.0",
+			path: localPackagePath,
+		});
+		await manager.init();
+
+		const results = await manager.search({ url: TEST_CANONICAL });
+		expect(results).toHaveLength(1);
+		expect(results[0]?.description).toBe("Search modified");
+		await manager.destroy();
+	});
+
+	test("should not modify original file on disk", async () => {
+		const manager = CanonicalManager({
+			packages: [],
+			workingDir: path.join(tmpRoot, "working-dir-disk"),
+			preprocessPackage: (ctx: PreprocessContext): PreprocessContext => {
+				if (ctx.kind !== "resource") return ctx;
+				return {
+					...ctx,
+					resource: { ...ctx.resource, description: "Disk test modified" },
+				};
+			},
+		});
+
+		await manager.addLocalPackage({
+			name: "test.package",
+			version: "1.0.0",
+			path: localPackagePath,
+		});
+		await manager.init();
+
+		const resource = await manager.resolve(TEST_CANONICAL);
+		expect(resource.description).toBe("Disk test modified");
+
+		// File on disk should remain unchanged
+		const fileContent = JSON.parse(await fs.readFile(resourceFilePath, "utf-8"));
+		expect(fileContent.description).toBe("Original description");
+		await manager.destroy();
+	});
+
+	test("should receive correct package info in context", async () => {
+		let receivedPackage: { name: string; version: string } | undefined;
+
+		const manager = CanonicalManager({
+			packages: [],
+			workingDir: path.join(tmpRoot, "working-dir-pkg"),
+			preprocessPackage: (ctx: PreprocessContext): PreprocessContext => {
+				if (ctx.kind !== "resource") return ctx;
+				receivedPackage = ctx.package;
+				return ctx;
+			},
+		});
+
+		await manager.addLocalPackage({
+			name: "test.package",
+			version: "1.0.0",
+			path: localPackagePath,
+		});
+		await manager.init();
+
+		await manager.resolve(TEST_CANONICAL);
+		expect(receivedPackage).toEqual({ name: "test.package", version: "1.0.0" });
+		await manager.destroy();
+	});
+
+	test("should handle both package and resource kinds in one hook", async () => {
+		const manager = CanonicalManager({
+			packages: [],
+			workingDir: path.join(tmpRoot, "working-dir-both"),
+			preprocessPackage: (ctx: PreprocessContext): PreprocessContext => {
+				if (ctx.kind === "package") {
+					// Pass through package preprocessing unchanged
+					return ctx;
+				}
+				if (ctx.kind === "resource") {
+					return {
+						...ctx,
+						resource: { ...ctx.resource, description: "Both kinds work" },
+					};
+				}
+				return ctx;
+			},
+		});
+
+		await manager.addLocalPackage({
+			name: "test.package",
+			version: "1.0.0",
+			path: localPackagePath,
+		});
+		await manager.init();
+
+		const resource = await manager.resolve(TEST_CANONICAL);
+		expect(resource.description).toBe("Both kinds work");
+		await manager.destroy();
+	});
+});

--- a/test/unit/scanner/scanner.test.ts
+++ b/test/unit/scanner/scanner.test.ts
@@ -11,7 +11,7 @@ import {
     processIndex,
     scanDirectory,
 } from "../../../src/scanner";
-import type { PackageJson } from "../../../src/types";
+import type { PackageJson, PreprocessContext } from "../../../src/types";
 
 describe("Scanner Module", () => {
     let tempDir: string;
@@ -427,11 +427,12 @@ describe("Scanner Module", () => {
             );
 
             // Hook that fixes the typo
-            const preprocessPackage = ({ packageJson }: { packageJson: Record<string, unknown> }) => {
-                if (packageJson.name === "test.packge") {
-                    return { packageJson: { ...packageJson, name: "test.package" } };
+            const preprocessPackage = (ctx: PreprocessContext): PreprocessContext => {
+                if (ctx.kind !== "package") return ctx;
+                if (ctx.packageJson.name === "test.packge") {
+                    return { ...ctx, packageJson: { ...ctx.packageJson, name: "test.package" } };
                 }
-                return { packageJson };
+                return ctx;
             };
 
             await loadPackage(packagePath, cache, preprocessPackage);
@@ -473,8 +474,9 @@ describe("Scanner Module", () => {
                 }),
             );
 
-            const preprocessPackage = ({ packageJson }: { packageJson: Record<string, unknown> }) => {
-                return { packageJson: { ...packageJson, name: "modified.name" } };
+            const preprocessPackage = (ctx: PreprocessContext): PreprocessContext => {
+                if (ctx.kind !== "package") return ctx;
+                return { ...ctx, packageJson: { ...ctx.packageJson, name: "modified.name" } };
             };
 
             await loadPackage(packagePath, cache, preprocessPackage);


### PR DESCRIPTION
## Summary

- Extend `preprocessPackage` callback to handle both package.json and resource modifications via a discriminated union (`kind: "package"` | `kind: "resource"`)
- Extract `PreprocessBaseContext` with shared `package: PackageId` field
- Apply the hook in `read()` so all `resolve()`, `search()`, and direct `read()` paths support in-memory resource patching
- Add 5 new tests covering resource modification, disk immutability, package context, and mixed usage

## Motivation

Closes the canonical-manager side of atomic-ehr/codegen#78. Previously, resource patching required a separate `patchSd` mechanism in the codegen register. This change lets users patch resources at the same level as package.json preprocessing, through a single unified hook.

## Test plan

- [x] Existing `preprocessPackage` tests updated and passing
- [x] New `preprocess-resource.test.ts` suite: modify via read(), modify via search(), verify disk unchanged, verify package info in context, handle both kinds in one hook
- [x] `bun run typecheck` passes
- [x] All 93 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)