### PR TITLE
fix: Add default export condition for CJS resolver compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
- Add `"default"` condition to `exports` map — fixes `ERR_PACKAGE_PATH_NOT_EXPORTED` when consumed via CJS resolvers (e.g. `tsx`)