### PR TITLE
feat: Add ignorePackageIndex option and warn on corrupt .index.json

### DIFF
--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -269,7 +269,9 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
         } else {
             await installPackages(packageSpecs, npmPackagePath, registry);
             await installConfiguredLocalPackages(npmPackagePath);
-            await scanDirectory(cache, npmPackagePath, config.preprocessPackage);
+            await scanDirectory(cache, npmPackagePath, config.preprocessPackage, {
+                ignorePackageIndex: config.ignorePackageIndex,
+            });
             await saveCacheRecordToDisk(cache, workingDir, cacheKey);
         }
 

--- a/src/scanner/directory.ts
+++ b/src/scanner/directory.ts
@@ -12,6 +12,7 @@ export const loadPackagesIntoCache = async (
     cache: ExtendedCache,
     pwd: string,
     preprocessPackage?: (context: PreprocessContext) => PreprocessContext,
+    options?: { ignorePackageIndex?: boolean },
 ): Promise<void> => {
     const nodeModulesPath = path.join(pwd, "node_modules");
     const entries = await fs.readdir(nodeModulesPath, { withFileTypes: true });
@@ -25,11 +26,11 @@ export const loadPackagesIntoCache = async (
             const scopedEntries = await fs.readdir(packagePath, { withFileTypes: true });
             for (const scopedEntry of scopedEntries) {
                 if (!scopedEntry.isDirectory()) continue;
-                const w = await loadPackage(path.join(packagePath, scopedEntry.name), cache, preprocessPackage);
+                const w = await loadPackage(path.join(packagePath, scopedEntry.name), cache, preprocessPackage, options);
                 if (w) warnings.push(w);
             }
         } else {
-            const w = await loadPackage(packagePath, cache, preprocessPackage);
+            const w = await loadPackage(packagePath, cache, preprocessPackage, options);
             if (w) warnings.push(w);
         }
     }

--- a/src/scanner/package.ts
+++ b/src/scanner/package.ts
@@ -91,6 +91,7 @@ export const loadPackage = async (
     packagePath: string,
     cache: ExtendedCache,
     preprocessPackage?: (context: PreprocessContext) => PreprocessContext,
+    options?: { ignorePackageIndex?: boolean },
 ): Promise<string | undefined> => {
     const packageJsonPath = path.join(packagePath, "package.json");
     if (!(await fileExists(packageJsonPath))) return undefined;
@@ -121,7 +122,7 @@ export const loadPackage = async (
         packageJson,
     };
 
-    const hasIndex = await fileExists(path.join(packagePath, ".index.json"));
+    const hasIndex = !options?.ignorePackageIndex && (await fileExists(path.join(packagePath, ".index.json")));
     const hasFhirVersions = Array.isArray(packageJson.fhirVersions) && packageJson.fhirVersions.length > 0;
     const hasCoreDep = isCorePackage(packageJson.name) || hasCorePackageDependency(packageJson.dependencies);
 

--- a/src/scanner/processor.ts
+++ b/src/scanner/processor.ts
@@ -5,6 +5,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ExtendedCache } from "../cache.js";
+import { fileExists } from "../fs/index.js";
 import type { IndexEntry, PackageJson } from "../types/index.js";
 import { parseIndex } from "./parser.js";
 
@@ -17,10 +18,16 @@ export const processIndex = async (basePath: string, packageJson: PackageJson, c
 
         if (!index) return;
 
+        let missingCount = 0;
         for (const file of index.files) {
             if (!file.url) continue;
 
             const filePath = path.join(basePath, file.filename);
+
+            if (!(await fileExists(filePath))) {
+                missingCount++;
+                continue;
+            }
 
             const id = cache.referenceManager.generateId({
                 packageName: packageJson.name,
@@ -58,6 +65,12 @@ export const processIndex = async (basePath: string, packageJson: PackageJson, c
             if (entries) {
                 entries.push(entry);
             }
+        }
+
+        if (missingCount > 0) {
+            console.warn(
+                `Warning: ${packageJson.name}@${packageJson.version} .index.json references ${missingCount} file(s) not found on disk — index may be corrupt`,
+            );
         }
     } catch {
         // Silently ignore index processing errors

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -91,6 +91,8 @@ export interface Config {
     dropCache?: boolean;
     /** Hook to preprocess packages and resources. Receives a discriminated union with `kind` field. */
     preprocessPackage?: (context: PreprocessContext) => PreprocessContext;
+    /** Ignore shipped .index.json files and force directory scanning for all packages. */
+    ignorePackageIndex?: boolean;
 }
 
 export interface TgzPackageConfig {

--- a/test/unit/scanner/scanner.test.ts
+++ b/test/unit/scanner/scanner.test.ts
@@ -13,6 +13,9 @@ import {
 } from "../../../src/scanner";
 import type { PackageJson, PreprocessContext } from "../../../src/types";
 
+/** Write an empty stub file so processIndex's fileExists check passes. */
+const touchFile = (filePath: string) => fs.writeFile(filePath, "{}");
+
 describe("Scanner Module", () => {
     let tempDir: string;
 
@@ -226,6 +229,8 @@ describe("Scanner Module", () => {
             };
 
             await fs.writeFile(path.join(packagePath, ".index.json"), JSON.stringify(indexContent));
+            await touchFile(path.join(packagePath, "Patient.json"));
+            await touchFile(path.join(packagePath, "Observation.json"));
 
             const packageJson: PackageJson = {
                 name: "test.package",
@@ -319,6 +324,7 @@ describe("Scanner Module", () => {
             };
 
             await fs.writeFile(path.join(packagePath, ".index.json"), JSON.stringify(indexContent));
+            await touchFile(path.join(packagePath, "Patient.json"));
 
             await loadPackage(packagePath, cache);
 
@@ -359,6 +365,7 @@ describe("Scanner Module", () => {
                     ],
                 }),
             );
+            await touchFile(path.join(packagePath, "Profile.json"));
 
             // Examples files
             await fs.writeFile(
@@ -375,6 +382,7 @@ describe("Scanner Module", () => {
                     ],
                 }),
             );
+            await touchFile(path.join(examplesPath, "example.json"));
 
             await loadPackage(packagePath, cache);
 
@@ -473,6 +481,7 @@ describe("Scanner Module", () => {
                     ],
                 }),
             );
+            await touchFile(path.join(packagePath, "Resource.json"));
 
             const preprocessPackage = (ctx: PreprocessContext): PreprocessContext => {
                 if (ctx.kind !== "package") return ctx;
@@ -521,6 +530,7 @@ describe("Scanner Module", () => {
                     ],
                 }),
             );
+            await touchFile(path.join(package1, "Resource1.json"));
 
             // Package 2 - Regular package (no .index.json)
             await fs.writeFile(
@@ -561,6 +571,7 @@ describe("Scanner Module", () => {
                     ],
                 }),
             );
+            await touchFile(path.join(packageDir, "Scoped.json"));
 
             await scanDirectory(cache, tempDir);
 


### PR DESCRIPTION
## Summary

- Add `ignorePackageIndex` config option that forces directory scanning instead of trusting shipped `.index.json` files
- `processIndex` now validates each file reference with `fileExists` before registering — missing entries are skipped
- Warns when `.index.json` references files not found on disk (corrupt index detection)

## Motivation

`de.basisprofil.r4@1.5.2` (transitive dep of `kbv.ita.for`) ships a `.index.json` that references 50 files in `examples/` without the path prefix. These files exist in `examples/` but the index points to the package root, causing `search()` → `read()` to throw ENOENT and kill the entire pipeline.

**Before:** any corrupt `.index.json` entry causes a fatal error in `search()`
```
error: Failed to read resource: ENOENT: .../de.basisprofil.r4/ConceptMap-ConceptMap-OPS-SNOMED-Category-Mapping.json
```

**After — with `ignorePackageIndex: true`:** shipped index is ignored, directory scan finds only real files
```ts
CanonicalManager({
    packages: [...],
    ignorePackageIndex: true, // bypass broken .index.json
})
```

**After — without the flag:** corrupt entries are skipped with a warning
```
Warning: de.basisprofil.r4@1.5.2 .index.json references 50 file(s) not found on disk — index may be corrupt
```