### PR TITLE
feat: write README.md index for cache directory

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@atomic-ehr/fhir-canonical-manager",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import * as afs from "node:fs/promises";
 import * as Path from "node:path";
 import { createReferenceManager, type ReferenceManager } from "./reference.js";
-import type { CacheData, CacheKey, IndexCache } from "./types/index.js";
+import type { CacheData, CacheKey, IndexCache, PackageInfo } from "./types/index.js";
 
 export interface ExtendedCache extends IndexCache {
     referenceManager: ReferenceManager;
@@ -60,7 +60,39 @@ export const loadCacheRecordFromDisk = async (pwd: string, cacheKey: CacheKey): 
     }
 };
 
-export const saveCacheRecordToDisk = async (cache: ExtendedCache, pwd: string, cacheKey: CacheKey): Promise<void> => {
+export const writeCacheReadme = async (pwd: string, cacheKey: CacheKey, packages: PackageInfo[]): Promise<void> => {
+    const readmePath = Path.join(pwd, "README.md");
+    let existing = "";
+    try {
+        existing = await afs.readFile(readmePath, "utf-8");
+    } catch {}
+
+    if (existing.includes(`\`${cacheKey}\``)) return;
+
+    const lines: string[] = [];
+    if (existing === "") {
+        lines.push("# FHIR Canonical Manager Cache", "");
+    }
+    lines.push(`- \`${cacheKey}\``);
+    const sorted = packages.map((p) => `${p.id.name}@${p.id.version}`).toSorted();
+    if (sorted.length === 0) {
+        lines.push("    - _no packages_");
+    } else {
+        for (const pkg of sorted) {
+            lines.push(`    - ${pkg}`);
+        }
+    }
+
+    const prefix = existing === "" ? "" : existing.replace(/\n*$/, "\n");
+    await afs.writeFile(readmePath, prefix + lines.join("\n") + "\n");
+};
+
+export const saveCacheRecordToDisk = async (
+    cache: ExtendedCache,
+    pwd: string,
+    packages: string[],
+): Promise<void> => {
+    const cacheKey = computeCacheKey(packages);
     const cacheData: CacheData = {
         entries: cache.entries,
         packages: cache.packages,
@@ -70,6 +102,7 @@ export const saveCacheRecordToDisk = async (cache: ExtendedCache, pwd: string, c
     cacheData.packageLockHash = await calculatePackageLockHash(npmPackagePath);
     cacheData.cacheKey = cacheKey;
     await afs.mkdir(cacheRecordPath, { recursive: true });
+    await writeCacheReadme(pwd, cacheKey, Object.values(cache.packages));
     await afs.writeFile(cacheIndexFile, JSON.stringify(cacheData, null, 2));
 };
 
@@ -81,5 +114,6 @@ export const flushCache = async (workingDir: string): Promise<void> => {
                 await afs.rm(Path.join(workingDir, entry.name), { recursive: true, force: true });
             }
         }
+        await afs.rm(Path.join(workingDir, "README.md"), { force: true });
     } catch {}
 };

--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -272,7 +272,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
             await scanDirectory(cache, npmPackagePath, config.preprocessPackage, {
                 ignorePackageIndex: config.ignorePackageIndex,
             });
-            await saveCacheRecordToDisk(cache, workingDir, cacheKey);
+            await saveCacheRecordToDisk(cache, workingDir, getCacheKeyPackages());
         }
 
         initialized = true;

--- a/test/unit/cache/cache.test.ts
+++ b/test/unit/cache/cache.test.ts
@@ -77,7 +77,7 @@ describe("Cache Module", () => {
             cache.referenceManager.set("ref-id", metadata);
 
             const cacheKey = computeCacheKey(["test.package"]);
-            await saveCacheRecordToDisk(cache, cacheDir, cacheKey);
+            await saveCacheRecordToDisk(cache, cacheDir, ["test.package"]);
 
             const cacheFile = path.join(cacheDir, cacheKey, "index.json");
             const exists = await fs
@@ -101,7 +101,7 @@ describe("Cache Module", () => {
             await fs.mkdir(cacheDir, { recursive: true });
 
             const cacheKey = computeCacheKey(["test.package"]);
-            await saveCacheRecordToDisk(cache, cacheDir, cacheKey);
+            await saveCacheRecordToDisk(cache, cacheDir, ["test.package"]);
 
             const cacheFile = path.join(cacheDir, cacheKey, "index.json");
             const content = await fs.readFile(cacheFile, "utf-8");
@@ -248,7 +248,7 @@ describe("Cache Module", () => {
 
             // Save
             const cacheKey = computeCacheKey(["test.package"]);
-            await saveCacheRecordToDisk(cache, cacheDir, cacheKey);
+            await saveCacheRecordToDisk(cache, cacheDir, ["test.package"]);
 
             // Load
             const loaded = await loadCacheRecordFromDisk(cacheDir, cacheKey);


### PR DESCRIPTION
## Summary
- Generate `README.md` at the cache root listing each cache hash directory and the packages it contains
- README is written when the cache record path is created (right after `mkdir`), and removed by `flushCache`
- `saveCacheRecordToDisk` now takes `packages: string[]` and derives the `cacheKey` internally; the README package list comes from `cache.packages`

## Test plan
- [x] `bun test test/unit` (93 pass)
- [x] Manual end-to-end check — confirmed two-level listing (hash → packages) and README removal on flush