### PR TITLE
feat: allow specifying package manager via Config

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"c980450c-b01e-4c43-a71d-6950bae6bc27","pid":47262,"procStart":"Thu Apr 30 07:53:08 2026","acquiredAt":1777545736506}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"c980450c-b01e-4c43-a71d-6950bae6bc27","pid":47262,"procStart":"Thu Apr 30 07:53:08 2026","acquiredAt":1777545736506}

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ tmp/
 
 # Zed
 .zed/
+
+# Claude Code runtime state
+.claude/scheduled_tasks.lock

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -8,8 +8,8 @@ export interface ExtendedCache extends IndexCache {
     referenceManager: ReferenceManager;
 }
 
-export const computeCacheKey = (packages: string[]): CacheKey => {
-    const content = JSON.stringify(packages.toSorted());
+export const computeCacheKey = (packageManager: PackageManager, packages: string[]): CacheKey => {
+    const content = JSON.stringify({ packageManager, packages: packages.toSorted() });
     const hash = createHash("sha256").update(content).digest("hex");
     return hash as CacheKey;
 };
@@ -22,8 +22,8 @@ const cacheRecordPathsFromKey = (pwd: string, cacheKey: CacheKey) => {
     return { cacheKey, cacheRecordPath, cacheIndexFile, npmPackagePath, npmRootPackageJsonFile };
 };
 
-export const cacheRecordPaths = (pwd: string, packages: string[]) => {
-    const cacheKey = computeCacheKey(packages);
+export const cacheRecordPaths = (pwd: string, packageManager: PackageManager, packages: string[]) => {
+    const cacheKey = computeCacheKey(packageManager, packages);
     return cacheRecordPathsFromKey(pwd, cacheKey);
 };
 
@@ -63,8 +63,8 @@ export const loadCacheRecordFromDisk = async (pwd: string, cacheKey: CacheKey): 
 export const writeCacheReadme = async (
     pwd: string,
     cacheKey: CacheKey,
-    packages: PackageInfo[],
     packageManager: PackageManager,
+    packages: PackageInfo[],
 ): Promise<void> => {
     const readmePath = Path.join(pwd, "README.md");
     let existing = "";
@@ -95,10 +95,10 @@ export const writeCacheReadme = async (
 export const saveCacheRecordToDisk = async (
     cache: ExtendedCache,
     pwd: string,
-    packages: string[],
     packageManager: PackageManager,
+    packages: string[],
 ): Promise<void> => {
-    const cacheKey = computeCacheKey(packages);
+    const cacheKey = computeCacheKey(packageManager, packages);
     const cacheData: CacheData = {
         entries: cache.entries,
         packages: cache.packages,
@@ -108,7 +108,7 @@ export const saveCacheRecordToDisk = async (
     cacheData.packageLockHash = await calculatePackageLockHash(npmPackagePath);
     cacheData.cacheKey = cacheKey;
     await afs.mkdir(cacheRecordPath, { recursive: true });
-    await writeCacheReadme(pwd, cacheKey, Object.values(cache.packages), packageManager);
+    await writeCacheReadme(pwd, cacheKey, packageManager, Object.values(cache.packages));
     await afs.writeFile(cacheIndexFile, JSON.stringify(cacheData, null, 2));
 };
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import * as afs from "node:fs/promises";
 import * as Path from "node:path";
 import { createReferenceManager, type ReferenceManager } from "./reference.js";
-import type { CacheData, CacheKey, IndexCache, PackageInfo } from "./types/index.js";
+import type { CacheData, CacheKey, IndexCache, PackageInfo, PackageManager } from "./types/index.js";
 
 export interface ExtendedCache extends IndexCache {
     referenceManager: ReferenceManager;
@@ -60,7 +60,12 @@ export const loadCacheRecordFromDisk = async (pwd: string, cacheKey: CacheKey): 
     }
 };
 
-export const writeCacheReadme = async (pwd: string, cacheKey: CacheKey, packages: PackageInfo[]): Promise<void> => {
+export const writeCacheReadme = async (
+    pwd: string,
+    cacheKey: CacheKey,
+    packages: PackageInfo[],
+    packageManager: PackageManager,
+): Promise<void> => {
     const readmePath = Path.join(pwd, "README.md");
     let existing = "";
     try {
@@ -73,7 +78,7 @@ export const writeCacheReadme = async (pwd: string, cacheKey: CacheKey, packages
     if (existing === "") {
         lines.push("# FHIR Canonical Manager Cache", "");
     }
-    lines.push(`- \`${cacheKey}\``);
+    lines.push(`- \`${cacheKey}\` (${packageManager})`);
     const sorted = packages.map((p) => `${p.id.name}@${p.id.version}`).toSorted();
     if (sorted.length === 0) {
         lines.push("    - _no packages_");
@@ -91,6 +96,7 @@ export const saveCacheRecordToDisk = async (
     cache: ExtendedCache,
     pwd: string,
     packages: string[],
+    packageManager: PackageManager,
 ): Promise<void> => {
     const cacheKey = computeCacheKey(packages);
     const cacheData: CacheData = {
@@ -102,7 +108,7 @@ export const saveCacheRecordToDisk = async (
     cacheData.packageLockHash = await calculatePackageLockHash(npmPackagePath);
     cacheData.cacheKey = cacheKey;
     await afs.mkdir(cacheRecordPath, { recursive: true });
-    await writeCacheReadme(pwd, cacheKey, Object.values(cache.packages));
+    await writeCacheReadme(pwd, cacheKey, Object.values(cache.packages), packageManager);
     await afs.writeFile(cacheIndexFile, JSON.stringify(cacheData, null, 2));
 };
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -174,6 +174,7 @@ export function getConfigFromPackageJson(packageJson: any): Partial<Config> {
     return {
         packages: fcm.packages || [],
         registry: fcm.registry,
+        packageManager: fcm.packageManager,
         workingDir: process.cwd(),
     };
 }

--- a/src/local.ts
+++ b/src/local.ts
@@ -45,14 +45,14 @@ interface FhirResource {
 export const installTgzPackage = async (
     archivePath: string,
     destPath: string,
+    packageManager: PackageManager,
     registry?: string,
-    packageManager?: PackageManager,
 ): Promise<PackageId> => {
     if (!(await fileExists(archivePath))) {
         throw new Error(`TGZ archive not found: ${archivePath}`);
     }
 
-    await installPackages([archivePath], destPath, registry, packageManager);
+    await installPackages([archivePath], destPath, packageManager, registry);
 
     const rootPackageJsonPath = Path.join(destPath, "package.json");
     const rootPackageJson = JSON.parse(await afs.readFile(rootPackageJsonPath, "utf-8"));

--- a/src/local.ts
+++ b/src/local.ts
@@ -3,7 +3,7 @@ import * as Path from "node:path";
 import { ensureDir, fileExists } from "./fs/index.js";
 import { isPathSpec, parsePackageRef } from "./manager/package-spec.js";
 import { installPackages } from "./package.js";
-import type { LocalPackageConfig, PackageId } from "./types/index.js";
+import type { LocalPackageConfig, PackageId, PackageManager } from "./types/index.js";
 
 const parseDependencySpec = (spec: string): { name: string; version: string } | undefined => {
     const trimmed = spec.trim();
@@ -46,12 +46,13 @@ export const installTgzPackage = async (
     archivePath: string,
     destPath: string,
     registry?: string,
+    packageManager?: PackageManager,
 ): Promise<PackageId> => {
     if (!(await fileExists(archivePath))) {
         throw new Error(`TGZ archive not found: ${archivePath}`);
     }
 
-    await installPackages([archivePath], destPath, registry);
+    await installPackages([archivePath], destPath, registry, packageManager);
 
     const rootPackageJsonPath = Path.join(destPath, "package.json");
     const rootPackageJson = JSON.parse(await afs.readFile(rootPackageJsonPath, "utf-8"));

--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -95,7 +95,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
     };
     const getCacheKeyPackages = () => {
         const localParts = Array.from(localPackages.values()).map((entry) => entry.cacheKeyPart);
-        return [`__pm:${getResolvedPackageManager()}`, ...packageSpecs, ...localParts];
+        return [...packageSpecs, ...localParts];
     };
     const refreshLocalPackageCacheKeys = async (): Promise<void> => {
         if (localPackages.size === 0) return;
@@ -166,7 +166,11 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
 
     const packageRefToPackageMeta = async () => {
         ensureInitialized();
-        const { npmRootPackageJsonFile } = cacheRecordPaths(workingDir, getCacheKeyPackages());
+        const { npmRootPackageJsonFile } = cacheRecordPaths(
+            workingDir,
+            getResolvedPackageManager(),
+            getCacheKeyPackages(),
+        );
         const rootPackageDeps =
             (
                 JSON.parse(await afs.readFile(npmRootPackageJsonFile, "utf8")) as {
@@ -250,7 +254,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
         if (config.dropCache) {
             await flushCacheFromDisk(workingDir);
         }
-        const { cacheKey, npmPackagePath } = cacheRecordPaths(workingDir, getCacheKeyPackages());
+        const { cacheKey, npmPackagePath } = cacheRecordPaths(workingDir, resolvedPackageManager, getCacheKeyPackages());
 
         const cachedData = await loadCacheRecordFromDisk(workingDir, cacheKey);
         const nodeModulesPath = Path.join(npmPackagePath, "node_modules");
@@ -286,7 +290,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
             await scanDirectory(cache, npmPackagePath, config.preprocessPackage, {
                 ignorePackageIndex: config.ignorePackageIndex,
             });
-            await saveCacheRecordToDisk(cache, workingDir, getCacheKeyPackages(), resolvedPackageManager);
+            await saveCacheRecordToDisk(cache, workingDir, resolvedPackageManager, getCacheKeyPackages());
         }
 
         initialized = true;
@@ -553,7 +557,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
 
     const addTgzPackage = async (config: TgzPackageConfig): Promise<PackageId> => {
         const archivePath = Path.resolve(config.archivePath);
-        const { npmPackagePath } = cacheRecordPaths(workingDir, getCacheKeyPackages());
+        const { npmPackagePath } = cacheRecordPaths(workingDir, getResolvedPackageManager(), getCacheKeyPackages());
         await ensureDir(npmPackagePath);
 
         const { name, version } = await installTgzPackage(archivePath, npmPackagePath, registry, resolvedPackageManager);

--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -16,7 +16,7 @@ import {
 import { DEFAULT_REGISTRY } from "../constants.js";
 import { ensureDir, fileExists } from "../fs/index.js";
 import { installLocalFolder, installTgzPackage } from "../local.js";
-import { installPackages } from "../package.js";
+import { detectPackageManager, installPackages } from "../package.js";
 import { resolveWithContext } from "../resolver.js";
 import { scanDirectory } from "../scanner/index.js";
 import { filterBySmartSearch } from "../search/index.js";
@@ -28,6 +28,7 @@ import type {
     PackageId,
     PackageInfo,
     PackageJson,
+    PackageManager,
     Reference,
     Resource,
     SearchParameter,
@@ -85,9 +86,16 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
     const packageSpecs = [...(config.packages ?? [])].map(normalizePackageSpec);
     const localPackages = new Map<string, LocalPackageEntry>();
     const pathPackageMeta = new Map<string, PackageId>();
+    let resolvedPackageManager: PackageManager | undefined = config.packageManager;
+    const getResolvedPackageManager = (): PackageManager => {
+        if (!resolvedPackageManager) {
+            throw new Error("Package manager not resolved. Call init() first.");
+        }
+        return resolvedPackageManager;
+    };
     const getCacheKeyPackages = () => {
         const localParts = Array.from(localPackages.values()).map((entry) => entry.cacheKeyPart);
-        return [...packageSpecs, ...localParts];
+        return [`__pm:${getResolvedPackageManager()}`, ...packageSpecs, ...localParts];
     };
     const refreshLocalPackageCacheKeys = async (): Promise<void> => {
         if (localPackages.size === 0) return;
@@ -138,7 +146,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
         for (const entry of localPackages.values()) {
             await installLocalFolder(entry.config, npmPackagePath);
             if (!skipDependencyInstall && entry.config.dependencies && entry.config.dependencies.length > 0) {
-                await installPackages(entry.config.dependencies, npmPackagePath, registry);
+                await installPackages(entry.config.dependencies, npmPackagePath, registry, resolvedPackageManager);
             }
         }
     };
@@ -231,6 +239,12 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
     const init = async (): Promise<Record<string, PackageId>> => {
         if (initialized) return packageRefToPackageMeta();
 
+        if (!resolvedPackageManager) {
+            resolvedPackageManager = await detectPackageManager();
+            if (!resolvedPackageManager) {
+                throw new Error("No package manager found. Please install bun or npm.");
+            }
+        }
         await refreshLocalPackageCacheKeys();
         await ensureDir(workingDir);
         if (config.dropCache) {
@@ -267,12 +281,12 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
                 cache.referenceManager.set(id, metadata);
             });
         } else {
-            await installPackages(packageSpecs, npmPackagePath, registry);
+            await installPackages(packageSpecs, npmPackagePath, registry, resolvedPackageManager);
             await installConfiguredLocalPackages(npmPackagePath);
             await scanDirectory(cache, npmPackagePath, config.preprocessPackage, {
                 ignorePackageIndex: config.ignorePackageIndex,
             });
-            await saveCacheRecordToDisk(cache, workingDir, getCacheKeyPackages());
+            await saveCacheRecordToDisk(cache, workingDir, getCacheKeyPackages(), resolvedPackageManager);
         }
 
         initialized = true;
@@ -542,7 +556,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
         const { npmPackagePath } = cacheRecordPaths(workingDir, getCacheKeyPackages());
         await ensureDir(npmPackagePath);
 
-        const { name, version } = await installTgzPackage(archivePath, npmPackagePath, registry);
+        const { name, version } = await installTgzPackage(archivePath, npmPackagePath, registry, resolvedPackageManager);
 
         pathPackageMeta.set(archivePath, { name, version });
         if (!packageSpecs.includes(archivePath)) {

--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -86,13 +86,10 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
     const packageSpecs = [...(config.packages ?? [])].map(normalizePackageSpec);
     const localPackages = new Map<string, LocalPackageEntry>();
     const pathPackageMeta = new Map<string, PackageId>();
-    let resolvedPackageManager: PackageManager | undefined = config.packageManager;
-    const getResolvedPackageManager = (): PackageManager => {
-        if (!resolvedPackageManager) {
-            throw new Error("Package manager not resolved. Call init() first.");
-        }
-        return resolvedPackageManager;
-    };
+    const resolvedPackageManager = config.packageManager ?? detectPackageManager();
+    if (!resolvedPackageManager) {
+        throw new Error("No package manager found. Please install bun or npm, or set Config.packageManager.");
+    }
     const getCacheKeyPackages = () => {
         const localParts = Array.from(localPackages.values()).map((entry) => entry.cacheKeyPart);
         return [...packageSpecs, ...localParts];
@@ -166,11 +163,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
 
     const packageRefToPackageMeta = async () => {
         ensureInitialized();
-        const { npmRootPackageJsonFile } = cacheRecordPaths(
-            workingDir,
-            getResolvedPackageManager(),
-            getCacheKeyPackages(),
-        );
+        const { npmRootPackageJsonFile } = cacheRecordPaths(workingDir, resolvedPackageManager, getCacheKeyPackages());
         const rootPackageDeps =
             (
                 JSON.parse(await afs.readFile(npmRootPackageJsonFile, "utf8")) as {
@@ -243,12 +236,6 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
     const init = async (): Promise<Record<string, PackageId>> => {
         if (initialized) return packageRefToPackageMeta();
 
-        if (!resolvedPackageManager) {
-            resolvedPackageManager = await detectPackageManager();
-            if (!resolvedPackageManager) {
-                throw new Error("No package manager found. Please install bun or npm.");
-            }
-        }
         await refreshLocalPackageCacheKeys();
         await ensureDir(workingDir);
         if (config.dropCache) {
@@ -557,7 +544,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
 
     const addTgzPackage = async (config: TgzPackageConfig): Promise<PackageId> => {
         const archivePath = Path.resolve(config.archivePath);
-        const { npmPackagePath } = cacheRecordPaths(workingDir, getResolvedPackageManager(), getCacheKeyPackages());
+        const { npmPackagePath } = cacheRecordPaths(workingDir, resolvedPackageManager, getCacheKeyPackages());
         await ensureDir(npmPackagePath);
 
         const { name, version } = await installTgzPackage(archivePath, npmPackagePath, registry, resolvedPackageManager);

--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -86,8 +86,8 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
     const packageSpecs = [...(config.packages ?? [])].map(normalizePackageSpec);
     const localPackages = new Map<string, LocalPackageEntry>();
     const pathPackageMeta = new Map<string, PackageId>();
-    const resolvedPackageManager = config.packageManager ?? detectPackageManager();
-    if (!resolvedPackageManager) {
+    const packageManager = config.packageManager ?? detectPackageManager();
+    if (!packageManager) {
         throw new Error("No package manager found. Please install bun or npm, or set Config.packageManager.");
     }
     const getCacheKeyPackages = () => {
@@ -143,7 +143,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
         for (const entry of localPackages.values()) {
             await installLocalFolder(entry.config, npmPackagePath);
             if (!skipDependencyInstall && entry.config.dependencies && entry.config.dependencies.length > 0) {
-                await installPackages(entry.config.dependencies, npmPackagePath, resolvedPackageManager, registry);
+                await installPackages(entry.config.dependencies, npmPackagePath, packageManager, registry);
             }
         }
     };
@@ -163,7 +163,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
 
     const packageRefToPackageMeta = async () => {
         ensureInitialized();
-        const { npmRootPackageJsonFile } = cacheRecordPaths(workingDir, resolvedPackageManager, getCacheKeyPackages());
+        const { npmRootPackageJsonFile } = cacheRecordPaths(workingDir, packageManager, getCacheKeyPackages());
         const rootPackageDeps =
             (
                 JSON.parse(await afs.readFile(npmRootPackageJsonFile, "utf8")) as {
@@ -241,7 +241,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
         if (config.dropCache) {
             await flushCacheFromDisk(workingDir);
         }
-        const { cacheKey, npmPackagePath } = cacheRecordPaths(workingDir, resolvedPackageManager, getCacheKeyPackages());
+        const { cacheKey, npmPackagePath } = cacheRecordPaths(workingDir, packageManager, getCacheKeyPackages());
 
         const cachedData = await loadCacheRecordFromDisk(workingDir, cacheKey);
         const nodeModulesPath = Path.join(npmPackagePath, "node_modules");
@@ -272,12 +272,12 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
                 cache.referenceManager.set(id, metadata);
             });
         } else {
-            await installPackages(packageSpecs, npmPackagePath, resolvedPackageManager, registry);
+            await installPackages(packageSpecs, npmPackagePath, packageManager, registry);
             await installConfiguredLocalPackages(npmPackagePath);
             await scanDirectory(cache, npmPackagePath, config.preprocessPackage, {
                 ignorePackageIndex: config.ignorePackageIndex,
             });
-            await saveCacheRecordToDisk(cache, workingDir, resolvedPackageManager, getCacheKeyPackages());
+            await saveCacheRecordToDisk(cache, workingDir, packageManager, getCacheKeyPackages());
         }
 
         initialized = true;
@@ -544,10 +544,10 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
 
     const addTgzPackage = async (config: TgzPackageConfig): Promise<PackageId> => {
         const archivePath = Path.resolve(config.archivePath);
-        const { npmPackagePath } = cacheRecordPaths(workingDir, resolvedPackageManager, getCacheKeyPackages());
+        const { npmPackagePath } = cacheRecordPaths(workingDir, packageManager, getCacheKeyPackages());
         await ensureDir(npmPackagePath);
 
-        const { name, version } = await installTgzPackage(archivePath, npmPackagePath, resolvedPackageManager, registry);
+        const { name, version } = await installTgzPackage(archivePath, npmPackagePath, packageManager, registry);
 
         pathPackageMeta.set(archivePath, { name, version });
         if (!packageSpecs.includes(archivePath)) {

--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -143,7 +143,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
         for (const entry of localPackages.values()) {
             await installLocalFolder(entry.config, npmPackagePath);
             if (!skipDependencyInstall && entry.config.dependencies && entry.config.dependencies.length > 0) {
-                await installPackages(entry.config.dependencies, npmPackagePath, registry, resolvedPackageManager);
+                await installPackages(entry.config.dependencies, npmPackagePath, resolvedPackageManager, registry);
             }
         }
     };
@@ -272,7 +272,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
                 cache.referenceManager.set(id, metadata);
             });
         } else {
-            await installPackages(packageSpecs, npmPackagePath, registry, resolvedPackageManager);
+            await installPackages(packageSpecs, npmPackagePath, resolvedPackageManager, registry);
             await installConfiguredLocalPackages(npmPackagePath);
             await scanDirectory(cache, npmPackagePath, config.preprocessPackage, {
                 ignorePackageIndex: config.ignorePackageIndex,
@@ -547,7 +547,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
         const { npmPackagePath } = cacheRecordPaths(workingDir, resolvedPackageManager, getCacheKeyPackages());
         await ensureDir(npmPackagePath);
 
-        const { name, version } = await installTgzPackage(archivePath, npmPackagePath, registry, resolvedPackageManager);
+        const { name, version } = await installTgzPackage(archivePath, npmPackagePath, resolvedPackageManager, registry);
 
         pathPackageMeta.set(archivePath, { name, version });
         if (!packageSpecs.includes(archivePath)) {

--- a/src/package.ts
+++ b/src/package.ts
@@ -3,7 +3,7 @@
  * Merged from package/detector.ts, package/installer.ts, and package/index.ts
  */
 
-import { type ExecOptions, exec } from "node:child_process";
+import { type ExecOptions, exec, execSync } from "node:child_process";
 import * as afs from "node:fs/promises";
 import * as Path from "node:path";
 import { promisify } from "node:util";
@@ -28,18 +28,14 @@ const shellEscape = (str: string): string => {
     return str.replace(/'/g, "'\\''");
 };
 
-export const detectPackageManager = async (): Promise<PackageManager | undefined> => {
-    try {
-        await execAsync("bun --version");
-        return "bun";
-    } catch {
+export const detectPackageManager = (): PackageManager | undefined => {
+    for (const candidate of ["bun", "npm"] as const) {
         try {
-            await execAsync("npm --version");
-            return "npm";
-        } catch {
-            return;
-        }
+            execSync(`${candidate} --version`, { stdio: "ignore" });
+            return candidate;
+        } catch {}
     }
+    return undefined;
 };
 
 const ensurePackageJson = async (pwd: string) => {
@@ -141,7 +137,7 @@ export const installPackages = async (
     await ensureDir(pwd);
     await ensurePackageJson(pwd);
 
-    const resolvedPackageManager = packageManager ?? (await detectPackageManager());
+    const resolvedPackageManager = packageManager ?? detectPackageManager();
     if (!resolvedPackageManager) throw new Error("No package manager found. Please install bun or npm.");
 
     // Build a map of user-specified package names to their full refs

--- a/src/package.ts
+++ b/src/package.ts
@@ -8,10 +8,11 @@ import * as afs from "node:fs/promises";
 import * as Path from "node:path";
 import { promisify } from "node:util";
 import { ensureDir, fileExists } from "./fs/index.js";
+import type { PackageManager } from "./types/index.js";
+
+export type { PackageManager };
 
 const execAsync = promisify(exec);
-
-export type PackageManager = "bun" | "npm";
 
 const isValidPackageRef = (pkg: string): boolean => {
     if (pkg.startsWith("http://") || pkg.startsWith("https://")) {
@@ -131,12 +132,17 @@ const installSinglePackage = async (
     await execAsync(cmd, opt);
 };
 
-export const installPackages = async (packages: string[], pwd: string, registry?: string): Promise<void> => {
+export const installPackages = async (
+    packages: string[],
+    pwd: string,
+    registry?: string,
+    packageManager?: PackageManager,
+): Promise<void> => {
     await ensureDir(pwd);
     await ensurePackageJson(pwd);
 
-    const packageManager = await detectPackageManager();
-    if (!packageManager) throw new Error("No package manager found. Please install bun or npm.");
+    const resolvedPackageManager = packageManager ?? (await detectPackageManager());
+    if (!resolvedPackageManager) throw new Error("No package manager found. Please install bun or npm.");
 
     // Build a map of user-specified package names to their full refs
     // User-specified versions take precedence over transitive dependency versions
@@ -162,7 +168,7 @@ export const installPackages = async (packages: string[], pwd: string, registry?
         }
 
         try {
-            await installSinglePackage(pkg, pwd, packageManager, registry);
+            await installSinglePackage(pkg, pwd, resolvedPackageManager, registry);
             installed.add(packageName);
 
             // Read dependencies from installed package and install them recursively

--- a/src/package.ts
+++ b/src/package.ts
@@ -131,14 +131,11 @@ const installSinglePackage = async (
 export const installPackages = async (
     packages: string[],
     pwd: string,
+    packageManager: PackageManager,
     registry?: string,
-    packageManager?: PackageManager,
 ): Promise<void> => {
     await ensureDir(pwd);
     await ensurePackageJson(pwd);
-
-    const resolvedPackageManager = packageManager ?? detectPackageManager();
-    if (!resolvedPackageManager) throw new Error("No package manager found. Please install bun or npm.");
 
     // Build a map of user-specified package names to their full refs
     // User-specified versions take precedence over transitive dependency versions
@@ -164,7 +161,7 @@ export const installPackages = async (
         }
 
         try {
-            await installSinglePackage(pkg, pwd, resolvedPackageManager, registry);
+            await installSinglePackage(pkg, pwd, packageManager, registry);
             installed.add(packageName);
 
             // Read dependencies from installed package and install them recursively

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -84,11 +84,15 @@ export type PreprocessResourceContext = PreprocessBaseContext & {
 
 export type PreprocessContext = PreprocessPackageContext | PreprocessResourceContext;
 
+export type PackageManager = "bun" | "npm";
+
 export interface Config {
     packages: string[];
     workingDir: string;
     registry?: string;
     dropCache?: boolean;
+    /** Force a specific package manager; auto-detected when omitted. */
+    packageManager?: PackageManager;
     /** Hook to preprocess packages and resources. Receives a discriminated union with `kind` field. */
     preprocessPackage?: (context: PreprocessContext) => PreprocessContext;
     /** Ignore shipped .index.json files and force directory scanning for all packages. */

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -69,6 +69,7 @@ describe("CLI search output format", () => {
                     name: "test-project",
                     fcm: {
                         packages: ["hl7.fhir.r4.core@4.0.1"],
+                        packageManager: "bun",
                     },
                 });
                 writeNpmPackageJson(["hl7.fhir.r4.core@4.0.1"], {});
@@ -148,6 +149,7 @@ describe("CLI search output format", () => {
                     name: "test-project",
                     fcm: {
                         packages: ["hl7.fhir.r4.core@4.0.1"],
+                        packageManager: "bun",
                     },
                 });
                 writeNpmPackageJson(["hl7.fhir.r4.core@4.0.1"], {});
@@ -172,6 +174,7 @@ describe("CLI search output format", () => {
                     name: "test-project",
                     fcm: {
                         packages: ["hl7.fhir.r4.core@4.0.1"],
+                        packageManager: "bun",
                     },
                 });
                 writeNpmPackageJson(["hl7.fhir.r4.core@4.0.1"], {});
@@ -247,6 +250,7 @@ describe("CLI search output format", () => {
                     name: "test-project",
                     fcm: {
                         packages: ["hl7.fhir.r4.core@4.0.1"],
+                        packageManager: "bun",
                     },
                 });
                 writeNpmPackageJson(["hl7.fhir.r4.core@4.0.1"], {});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -72,8 +72,8 @@ describe("CLI search output format", () => {
                         packageManager: "bun",
                     },
                 });
-                writeNpmPackageJson(["hl7.fhir.r4.core@4.0.1"], {});
-                writeCacheIndex(["hl7.fhir.r4.core@4.0.1"], {
+                writeNpmPackageJson("bun", ["hl7.fhir.r4.core@4.0.1"], {});
+                writeCacheIndex("bun", ["hl7.fhir.r4.core@4.0.1"], {
                     packages: [
                         {
                             name: "hl7.fhir.r4.core",
@@ -152,8 +152,8 @@ describe("CLI search output format", () => {
                         packageManager: "bun",
                     },
                 });
-                writeNpmPackageJson(["hl7.fhir.r4.core@4.0.1"], {});
-                writeCacheIndex(["hl7.fhir.r4.core@4.0.1"], {
+                writeNpmPackageJson("bun", ["hl7.fhir.r4.core@4.0.1"], {});
+                writeCacheIndex("bun", ["hl7.fhir.r4.core@4.0.1"], {
                     packages: [{ name: "hl7.fhir.r4.core", version: "4.0.1" }],
                     entries: {},
                     references: {},
@@ -177,8 +177,8 @@ describe("CLI search output format", () => {
                         packageManager: "bun",
                     },
                 });
-                writeNpmPackageJson(["hl7.fhir.r4.core@4.0.1"], {});
-                writeCacheIndex(["hl7.fhir.r4.core@4.0.1"], {
+                writeNpmPackageJson("bun", ["hl7.fhir.r4.core@4.0.1"], {});
+                writeCacheIndex("bun", ["hl7.fhir.r4.core@4.0.1"], {
                     packages: [
                         {
                             name: "hl7.fhir.r4.core",
@@ -253,8 +253,8 @@ describe("CLI search output format", () => {
                         packageManager: "bun",
                     },
                 });
-                writeNpmPackageJson(["hl7.fhir.r4.core@4.0.1"], {});
-                writeCacheIndex(["hl7.fhir.r4.core@4.0.1"], {
+                writeNpmPackageJson("bun", ["hl7.fhir.r4.core@4.0.1"], {});
+                writeCacheIndex("bun", ["hl7.fhir.r4.core@4.0.1"], {
                     packages: [
                         {
                             name: "hl7.fhir.r4.core",

--- a/test/unit/cache/cache.test.ts
+++ b/test/unit/cache/cache.test.ts
@@ -77,7 +77,7 @@ describe("Cache Module", () => {
             cache.referenceManager.set("ref-id", metadata);
 
             const cacheKey = computeCacheKey(["test.package"]);
-            await saveCacheRecordToDisk(cache, cacheDir, ["test.package"]);
+            await saveCacheRecordToDisk(cache, cacheDir, ["test.package"], "bun");
 
             const cacheFile = path.join(cacheDir, cacheKey, "index.json");
             const exists = await fs
@@ -101,7 +101,7 @@ describe("Cache Module", () => {
             await fs.mkdir(cacheDir, { recursive: true });
 
             const cacheKey = computeCacheKey(["test.package"]);
-            await saveCacheRecordToDisk(cache, cacheDir, ["test.package"]);
+            await saveCacheRecordToDisk(cache, cacheDir, ["test.package"], "bun");
 
             const cacheFile = path.join(cacheDir, cacheKey, "index.json");
             const content = await fs.readFile(cacheFile, "utf-8");
@@ -248,7 +248,7 @@ describe("Cache Module", () => {
 
             // Save
             const cacheKey = computeCacheKey(["test.package"]);
-            await saveCacheRecordToDisk(cache, cacheDir, ["test.package"]);
+            await saveCacheRecordToDisk(cache, cacheDir, ["test.package"], "bun");
 
             // Load
             const loaded = await loadCacheRecordFromDisk(cacheDir, cacheKey);

--- a/test/unit/cache/cache.test.ts
+++ b/test/unit/cache/cache.test.ts
@@ -22,8 +22,8 @@ describe("Cache Module", () => {
 
     describe("computeCacheKey", () => {
         test("should compute consistent hash for same packages", () => {
-            const hash1 = computeCacheKey(["foo", "bar"]);
-            const hash2 = computeCacheKey(["bar", "foo"]);
+            const hash1 = computeCacheKey("bun", ["foo", "bar"]);
+            const hash2 = computeCacheKey("bun", ["bar", "foo"]);
 
             expect(hash1).toBeDefined();
             expect(typeof hash1).toBe("string");
@@ -32,14 +32,14 @@ describe("Cache Module", () => {
         });
 
         test("should compute different hashes for different package lists", () => {
-            const hash1 = computeCacheKey(["package-lock-test", "bun-lock-test"]);
-            const hash2 = computeCacheKey(["different-package"]);
+            const hash1 = computeCacheKey("bun", ["package-lock-test", "bun-lock-test"]);
+            const hash2 = computeCacheKey("bun", ["different-package"]);
 
             expect(hash1).not.toBe(hash2);
         });
 
         test("should handle empty package list", () => {
-            const hash = computeCacheKey([]);
+            const hash = computeCacheKey("bun", []);
 
             expect(hash).toBeDefined();
             expect(typeof hash).toBe("string");
@@ -76,8 +76,8 @@ describe("Cache Module", () => {
             };
             cache.referenceManager.set("ref-id", metadata);
 
-            const cacheKey = computeCacheKey(["test.package"]);
-            await saveCacheRecordToDisk(cache, cacheDir, ["test.package"], "bun");
+            const cacheKey = computeCacheKey("bun", ["test.package"]);
+            await saveCacheRecordToDisk(cache, cacheDir, "bun", ["test.package"]);
 
             const cacheFile = path.join(cacheDir, cacheKey, "index.json");
             const exists = await fs
@@ -100,8 +100,8 @@ describe("Cache Module", () => {
             const cacheDir = path.join(tempDir, "cache");
             await fs.mkdir(cacheDir, { recursive: true });
 
-            const cacheKey = computeCacheKey(["test.package"]);
-            await saveCacheRecordToDisk(cache, cacheDir, ["test.package"], "bun");
+            const cacheKey = computeCacheKey("bun", ["test.package"]);
+            await saveCacheRecordToDisk(cache, cacheDir, "bun", ["test.package"]);
 
             const cacheFile = path.join(cacheDir, cacheKey, "index.json");
             const content = await fs.readFile(cacheFile, "utf-8");
@@ -148,7 +148,7 @@ describe("Cache Module", () => {
                 packageLockHash: "abc123",
             };
 
-            const cacheKey = computeCacheKey(["test-package"]);
+            const cacheKey = computeCacheKey("bun", ["test-package"]);
             const cacheSubdir = path.join(cacheDir, cacheKey);
             await fs.mkdir(cacheSubdir, { recursive: true });
             await fs.writeFile(path.join(cacheSubdir, "index.json"), JSON.stringify(cacheData, null, 2));
@@ -162,7 +162,7 @@ describe("Cache Module", () => {
             const cacheDir = path.join(tempDir, "cache");
             await fs.mkdir(cacheDir, { recursive: true });
 
-            const cacheKey = computeCacheKey(["test-package"]);
+            const cacheKey = computeCacheKey("bun", ["test-package"]);
             const loaded = await loadCacheRecordFromDisk(cacheDir, cacheKey);
 
             expect(loaded).toBeUndefined();
@@ -172,7 +172,7 @@ describe("Cache Module", () => {
             const cacheDir = path.join(tempDir, "cache");
             await fs.mkdir(cacheDir, { recursive: true });
 
-            const cacheKey = computeCacheKey(["test-package"]);
+            const cacheKey = computeCacheKey("bun", ["test-package"]);
             const cacheSubdir = path.join(cacheDir, cacheKey);
             await fs.mkdir(cacheSubdir, { recursive: true });
             await fs.writeFile(path.join(cacheSubdir, "index.json"), "invalid json content");
@@ -183,7 +183,7 @@ describe("Cache Module", () => {
         });
 
         test("should return undefined when directory does not exist", async () => {
-            const cacheKey = computeCacheKey(["test-package"]);
+            const cacheKey = computeCacheKey("bun", ["test-package"]);
             const loaded = await loadCacheRecordFromDisk("/non/existent/path", cacheKey);
             expect(loaded).toBeUndefined();
         });
@@ -247,8 +247,8 @@ describe("Cache Module", () => {
             cache.referenceManager.set("id2", metadata2);
 
             // Save
-            const cacheKey = computeCacheKey(["test.package"]);
-            await saveCacheRecordToDisk(cache, cacheDir, ["test.package"], "bun");
+            const cacheKey = computeCacheKey("bun", ["test.package"]);
+            await saveCacheRecordToDisk(cache, cacheDir, "bun", ["test.package"]);
 
             // Load
             const loaded = await loadCacheRecordFromDisk(cacheDir, cacheKey);

--- a/test/unit/package/package.test.ts
+++ b/test/unit/package/package.test.ts
@@ -44,7 +44,7 @@ describe("Package Module", () => {
             // We can't easily mock the actual exec in Bun test
             // So we'll just test the package.json creation
             try {
-                await installPackages(["test-package"], tempDir, undefined);
+                await installPackages(["test-package"], tempDir, "bun");
             } catch {
                 // Installation will fail, but package.json should be created
             }
@@ -80,7 +80,7 @@ describe("Package Module", () => {
             await fs.writeFile(path.join(tempDir, "package.json"), JSON.stringify(existingPackage));
 
             try {
-                await installPackages(["test-package"], tempDir, undefined);
+                await installPackages(["test-package"], tempDir, "bun");
             } catch {
                 // Installation will fail, but that's ok
             }

--- a/test/unit/package/package.test.ts
+++ b/test/unit/package/package.test.ts
@@ -18,7 +18,7 @@ describe("Package Module", () => {
     describe("detectPackageManager", () => {
         test("should detect bun when available", async () => {
             // This test will actually check for bun on the system
-            const result = await detectPackageManager();
+            const result = detectPackageManager();
 
             // On systems with bun installed, this should return 'bun'
             // On CI or other systems, it might return 'npm' or null
@@ -26,7 +26,7 @@ describe("Package Module", () => {
         });
 
         test("should return string or null", async () => {
-            const result = await detectPackageManager();
+            const result = detectPackageManager();
 
             if (result !== null) {
                 expect(typeof result).toBe("string");

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -36,18 +36,14 @@ export const writePackage = async (content: any) => {
     afs.writeFileSync("package.json", JSON.stringify(content, null, 2));
 };
 
-export const writeNpmPackageJson = async (
-    packages: string[],
-    content: any,
-    packageManager: PackageManager = "bun",
-) => {
+export const writeNpmPackageJson = async (packageManager: PackageManager, packages: string[], content: any) => {
     const { npmPackagePath, npmRootPackageJsonFile } = cacheRecordPaths(process.cwd(), packageManager, packages);
     afs.mkdirSync(npmPackagePath, { recursive: true });
     afs.mkdirSync(Path.join(npmPackagePath, "node_modules"), { recursive: true });
     afs.writeFileSync(npmRootPackageJsonFile, JSON.stringify(content, null, 2));
 };
 
-export const writeCacheIndex = async (packages: string[], content: any, packageManager: PackageManager = "bun") => {
+export const writeCacheIndex = async (packageManager: PackageManager, packages: string[], content: any) => {
     const {
         cacheIndexFile: cacheIndex,
         cacheRecordPath,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,10 @@
 import * as afs from "node:fs";
 import * as Path from "node:path";
 import { cacheRecordPaths } from "../src/cache";
+import type { PackageManager } from "../src/types";
+
+const cacheKeyInput = (packages: string[], packageManager: PackageManager = "bun"): string[] =>
+    [`__pm:${packageManager}`, ...packages];
 
 export const catchConsole = async (action: () => Promise<void>): Promise<string[]> => {
     const consoleOutput: string[] = [];
@@ -35,15 +39,26 @@ export const writePackage = async (content: any) => {
     afs.writeFileSync("package.json", JSON.stringify(content, null, 2));
 };
 
-export const writeNpmPackageJson = async (packages: string[], content: any) => {
-    const { npmPackagePath, npmRootPackageJsonFile } = cacheRecordPaths(process.cwd(), packages);
+export const writeNpmPackageJson = async (
+    packages: string[],
+    content: any,
+    packageManager: PackageManager = "bun",
+) => {
+    const { npmPackagePath, npmRootPackageJsonFile } = cacheRecordPaths(
+        process.cwd(),
+        cacheKeyInput(packages, packageManager),
+    );
     afs.mkdirSync(npmPackagePath, { recursive: true });
     afs.mkdirSync(Path.join(npmPackagePath, "node_modules"), { recursive: true });
     afs.writeFileSync(npmRootPackageJsonFile, JSON.stringify(content, null, 2));
 };
 
-export const writeCacheIndex = async (packages: string[], content: any) => {
-    const { cacheIndexFile: cacheIndex, cacheRecordPath, cacheKey } = cacheRecordPaths(process.cwd(), packages);
+export const writeCacheIndex = async (packages: string[], content: any, packageManager: PackageManager = "bun") => {
+    const {
+        cacheIndexFile: cacheIndex,
+        cacheRecordPath,
+        cacheKey,
+    } = cacheRecordPaths(process.cwd(), cacheKeyInput(packages, packageManager));
     content.packageLockHash = cacheKey;
     content.cacheKey = cacheKey; // Required for cache validation
     afs.mkdirSync(cacheRecordPath, { recursive: true });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -3,9 +3,6 @@ import * as Path from "node:path";
 import { cacheRecordPaths } from "../src/cache";
 import type { PackageManager } from "../src/types";
 
-const cacheKeyInput = (packages: string[], packageManager: PackageManager = "bun"): string[] =>
-    [`__pm:${packageManager}`, ...packages];
-
 export const catchConsole = async (action: () => Promise<void>): Promise<string[]> => {
     const consoleOutput: string[] = [];
     const originalLog = console.log;
@@ -44,10 +41,7 @@ export const writeNpmPackageJson = async (
     content: any,
     packageManager: PackageManager = "bun",
 ) => {
-    const { npmPackagePath, npmRootPackageJsonFile } = cacheRecordPaths(
-        process.cwd(),
-        cacheKeyInput(packages, packageManager),
-    );
+    const { npmPackagePath, npmRootPackageJsonFile } = cacheRecordPaths(process.cwd(), packageManager, packages);
     afs.mkdirSync(npmPackagePath, { recursive: true });
     afs.mkdirSync(Path.join(npmPackagePath, "node_modules"), { recursive: true });
     afs.writeFileSync(npmRootPackageJsonFile, JSON.stringify(content, null, 2));
@@ -58,7 +52,7 @@ export const writeCacheIndex = async (packages: string[], content: any, packageM
         cacheIndexFile: cacheIndex,
         cacheRecordPath,
         cacheKey,
-    } = cacheRecordPaths(process.cwd(), cacheKeyInput(packages, packageManager));
+    } = cacheRecordPaths(process.cwd(), packageManager, packages);
     content.packageLockHash = cacheKey;
     content.cacheKey = cacheKey; // Required for cache validation
     afs.mkdirSync(cacheRecordPath, { recursive: true });


### PR DESCRIPTION
## Summary
- Add optional `packageManager: "bun" | "npm"` to `Config`; falls back to `detectPackageManager()` when omitted
- Resolve the package manager once during `init()` and thread it through `installPackages`, `installTgzPackage`, and `saveCacheRecordToDisk`
- Include the resolved manager in the cache key so caches built with bun and npm don't collide
- README labels each hash entry with its manager, e.g. `` - `<hash>` (bun) ``

## Test plan
- [x] `bun test test/unit` (93 pass)
- [x] Manual end-to-end check — same packages produce different cache hashes for `bun` vs `npm`, and the README shows the manager next to each hash