### PR TITLE
feat: packageIndex mode (use/recover/regenerate), deprecate ignorePackageIndex

### DIFF
--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -18,7 +18,7 @@ import { ensureDir, fileExists } from "../fs/index.js";
 import { installLocalFolder, installTgzPackage } from "../local.js";
 import { detectPackageManager, installPackages } from "../package.js";
 import { resolveWithContext } from "../resolver.js";
-import { scanDirectory } from "../scanner/index.js";
+import { loadPackagesIntoCache } from "../scanner/index.js";
 import { filterBySmartSearch } from "../search/index.js";
 import type {
     CanonicalManager,
@@ -26,9 +26,9 @@ import type {
     IndexEntry,
     LocalPackageConfig,
     PackageId,
+    PackageIndexMode,
     PackageInfo,
     PackageJson,
-    PackageManager,
     Reference,
     Resource,
     SearchParameter,
@@ -36,6 +36,25 @@ import type {
     TgzPackageConfig,
 } from "../types/index.js";
 import { isPathSpec, normalizePackageSpec, parsePackageRef } from "./package-spec.js";
+
+/**
+ * Resolve the effective `packageIndex` mode, translating the deprecated
+ * `ignorePackageIndex` boolean. Throws if both are set.
+ */
+const resolvePackageIndexMode = (config: Config): PackageIndexMode => {
+    // No deprecated flag → just use packageIndex (default "use").
+    if (config.ignorePackageIndex === undefined) return config.packageIndex ?? "use";
+
+    if (config.packageIndex !== undefined) {
+        throw new Error(
+            "Cannot set both `packageIndex` and the deprecated `ignorePackageIndex`. Use `packageIndex` only.",
+        );
+    }
+    console.warn(
+        '`ignorePackageIndex` is deprecated; use `packageIndex` instead ("regenerate" replaces `true`, "use" replaces `false`).',
+    );
+    return config.ignorePackageIndex ? "regenerate" : "use";
+};
 
 interface LocalPackageEntry {
     config: LocalPackageConfig & { path: string };
@@ -236,6 +255,9 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
     const init = async (): Promise<Record<string, PackageId>> => {
         if (initialized) return packageRefToPackageMeta();
 
+        // Validate + resolve up front so the both-set error / deprecation fires regardless of cache state.
+        const packageIndexMode = resolvePackageIndexMode(config);
+
         await refreshLocalPackageCacheKeys();
         await ensureDir(workingDir);
         if (config.dropCache) {
@@ -274,8 +296,9 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
         } else {
             await installPackages(packageSpecs, npmPackagePath, packageManager, registry);
             await installConfiguredLocalPackages(npmPackagePath);
-            await scanDirectory(cache, npmPackagePath, config.preprocessPackage, {
-                ignorePackageIndex: config.ignorePackageIndex,
+            await loadPackagesIntoCache(cache, npmPackagePath, {
+                packageIndexMode,
+                preprocessPackage: config.preprocessPackage ?? ((e) => e),
             });
             await saveCacheRecordToDisk(cache, workingDir, packageManager, getCacheKeyPackages());
         }

--- a/src/scanner/directory.ts
+++ b/src/scanner/directory.ts
@@ -5,15 +5,9 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ExtendedCache } from "../cache.js";
-import type { PreprocessContext } from "../types/index.js";
-import { loadPackage } from "./package.js";
+import { loadPackage, type ScanOptions } from "./package.js";
 
-export const loadPackagesIntoCache = async (
-    cache: ExtendedCache,
-    pwd: string,
-    preprocessPackage?: (context: PreprocessContext) => PreprocessContext,
-    options?: { ignorePackageIndex?: boolean },
-): Promise<void> => {
+export const loadPackagesIntoCache = async (cache: ExtendedCache, pwd: string, options: ScanOptions): Promise<void> => {
     const nodeModulesPath = path.join(pwd, "node_modules");
     const entries = await fs.readdir(nodeModulesPath, { withFileTypes: true });
     const warnings: string[] = [];
@@ -26,11 +20,11 @@ export const loadPackagesIntoCache = async (
             const scopedEntries = await fs.readdir(packagePath, { withFileTypes: true });
             for (const scopedEntry of scopedEntries) {
                 if (!scopedEntry.isDirectory()) continue;
-                const w = await loadPackage(path.join(packagePath, scopedEntry.name), cache, preprocessPackage, options);
+                const w = await loadPackage(path.join(packagePath, scopedEntry.name), cache, options);
                 if (w) warnings.push(w);
             }
         } else {
-            const w = await loadPackage(packagePath, cache, preprocessPackage, options);
+            const w = await loadPackage(packagePath, cache, options);
             if (w) warnings.push(w);
         }
     }

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -2,7 +2,7 @@
  * Scanner module exports
  */
 
-export { loadPackagesIntoCache as scanDirectory } from "./directory.js";
+export { loadPackagesIntoCache } from "./directory.js";
 export { loadPackage } from "./package.js";
 export { isValidFileEntry, isValidIndexFile, parseIndex } from "./parser.js";
 export { processIndex } from "./processor.js";

--- a/src/scanner/package.ts
+++ b/src/scanner/package.ts
@@ -6,8 +6,8 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ExtendedCache } from "../cache.js";
 import { fileExists } from "../fs/index.js";
-import type { IndexEntry, PackageJson, PreprocessContext } from "../types/index.js";
-import { processIndex } from "./processor.js";
+import type { IndexEntry, PackageIndexMode, PackageJson, PreprocessContext } from "../types/index.js";
+import { collectFromIndex, commitEntries } from "./processor.js";
 
 const scanDirectoryForResources = async (
     dirPath: string,
@@ -83,6 +83,59 @@ const hasCorePackageDependency = (dependencies: Record<string, string> | undefin
     return Object.keys(dependencies).some(isCorePackage);
 };
 
+/** Options for scanning a package into the cache. The mode is resolved by the caller. */
+export type ScanOptions = {
+    packageIndexMode: PackageIndexMode;
+    preprocessPackage: (context: PreprocessContext) => PreprocessContext;
+};
+
+/**
+ * Load a package's resources into the cache: use the shipped index, scan the directory,
+ * or recover (scan when the index is corrupt). Returns the committed count and whether
+ * the shipped index was used (drives the "no .index.json" diagnostic).
+ */
+const loadResources = async (
+    packagePath: string,
+    packageJson: PackageJson,
+    cache: ExtendedCache,
+    mode: PackageIndexMode,
+): Promise<{ count: number; usedIndex: boolean }> => {
+    const pkgId = `${packageJson.name}@${packageJson.version}`;
+
+    // No usable shipped index → scan the directory.
+    if (mode === "regenerate" || !(await fileExists(path.join(packagePath, ".index.json")))) {
+        const count = await scanDirectoryForResources(packagePath, packageJson, cache);
+        if (count > 0) {
+            console.warn(`Warning: index generated for ${packageJson.name} (${count} resources)`);
+        }
+        return { count, usedIndex: false };
+    }
+
+    const { result, entries } = await collectFromIndex(packagePath);
+
+    // Corrupt index: "recover" scans the directory; "use" keeps the partial set and warns.
+    if (!result.ok) {
+        if (mode === "recover") {
+            console.warn(`Recovered ${pkgId}: .index.json is ${result.reason}; scanning directory instead.`);
+            return { count: await scanDirectoryForResources(packagePath, packageJson, cache), usedIndex: false };
+        }
+        const count = commitEntries(cache, packageJson, entries);
+        console.warn(
+            `Warning: ${pkgId} .index.json is ${result.reason}; loaded ${count} resource(s). ` +
+                `Set packageIndex: "recover" to fall back to a directory scan.`,
+        );
+        return { count, usedIndex: true };
+    }
+
+    // Usable shipped index (plus any examples index).
+    let count = commitEntries(cache, packageJson, entries);
+    const examplesPath = path.join(packagePath, "examples");
+    if (await fileExists(path.join(examplesPath, ".index.json"))) {
+        count += commitEntries(cache, packageJson, (await collectFromIndex(examplesPath)).entries);
+    }
+    return { count, usedIndex: true };
+};
+
 /**
  * Load a package into cache. Always registers. Scans resources if possible.
  * Returns a warning string if there's something to warn about, undefined otherwise.
@@ -90,9 +143,10 @@ const hasCorePackageDependency = (dependencies: Record<string, string> | undefin
 export const loadPackage = async (
     packagePath: string,
     cache: ExtendedCache,
-    preprocessPackage?: (context: PreprocessContext) => PreprocessContext,
-    options?: { ignorePackageIndex?: boolean },
+    options: ScanOptions,
 ): Promise<string | undefined> => {
+    const { packageIndexMode: mode, preprocessPackage } = options;
+
     const packageJsonPath = path.join(packagePath, "package.json");
     if (!(await fileExists(packageJsonPath))) return undefined;
 
@@ -100,14 +154,12 @@ export const loadPackage = async (
     try {
         const content = await fs.readFile(packageJsonPath, "utf-8");
         let parsed = JSON.parse(content);
-        if (preprocessPackage) {
-            const result = preprocessPackage({
-                kind: "package",
-                packageJson: parsed,
-                package: { name: parsed.name, version: parsed.version },
-            });
-            if (result.kind === "package") parsed = result.packageJson;
-        }
+        const result = preprocessPackage({
+            kind: "package",
+            packageJson: parsed,
+            package: { name: parsed.name, version: parsed.version },
+        });
+        if (result.kind === "package") parsed = result.packageJson;
         packageJson = parsed as PackageJson;
     } catch {
         return undefined;
@@ -122,31 +174,16 @@ export const loadPackage = async (
         packageJson,
     };
 
-    const hasIndex = !options?.ignorePackageIndex && (await fileExists(path.join(packagePath, ".index.json")));
-    const hasFhirVersions = Array.isArray(packageJson.fhirVersions) && packageJson.fhirVersions.length > 0;
-    const hasCoreDep = isCorePackage(packageJson.name) || hasCorePackageDependency(packageJson.dependencies);
-
-    let resourceCount = 0;
-    if (hasIndex) {
-        await processIndex(packagePath, packageJson, cache);
-        const examplesPath = path.join(packagePath, "examples");
-        if (await fileExists(path.join(examplesPath, ".index.json"))) {
-            await processIndex(examplesPath, packageJson, cache);
-        }
-        resourceCount = 1; // Has index, assume it has resources
-    } else {
-        resourceCount = await scanDirectoryForResources(packagePath, packageJson, cache);
-        if (resourceCount > 0) {
-            console.warn(`Warning: index generated for ${packageJson.name} (${resourceCount} resources)`);
-        }
-    }
+    const { count, usedIndex } = await loadResources(packagePath, packageJson, cache, mode);
 
     // No resources = not a FHIR package, no warning needed
-    if (resourceCount === 0) return undefined;
+    if (count === 0) return undefined;
 
     // Collect issues
+    const hasFhirVersions = Array.isArray(packageJson.fhirVersions) && packageJson.fhirVersions.length > 0;
+    const hasCoreDep = isCorePackage(packageJson.name) || hasCorePackageDependency(packageJson.dependencies);
     const issues: string[] = [];
-    if (!hasIndex) issues.push("no .index.json");
+    if (!usedIndex) issues.push("no .index.json");
     if (!hasFhirVersions) issues.push("no fhirVersions");
     if (!hasCoreDep) issues.push("no core dependency");
 

--- a/src/scanner/processor.ts
+++ b/src/scanner/processor.ts
@@ -9,70 +9,113 @@ import { fileExists } from "../fs/index.js";
 import type { IndexEntry, PackageJson } from "../types/index.js";
 import { parseIndex } from "./parser.js";
 
-export const processIndex = async (basePath: string, packageJson: PackageJson, cache: ExtendedCache): Promise<void> => {
+/** A resource discovered from an index or directory scan, not yet committed to the cache. */
+export type CollectedEntry = {
+    filePath: string;
+    resourceType: string;
+    url: string;
+    version?: string;
+    kind?: string;
+    type?: string;
+    indexVersion: number;
+};
+
+/** Outcome of reading a `.index.json`. `count` may be 0 for a legitimately resource-free index. */
+export type IndexLoadResult = { ok: true; count: number } | { ok: false; reason: "unparseable" | "missing-files" };
+
+/**
+ * Read and validate a package `.index.json`, collecting entries **without** mutating the
+ * cache. On `"missing-files"` the partial (resolvable) set is still returned, so callers
+ * can choose to commit it (`"use"`) or discard it and fall back to a scan (`"recover"`).
+ */
+export const collectFromIndex = async (
+    basePath: string,
+): Promise<{ result: IndexLoadResult; entries: CollectedEntry[] }> => {
     const indexPath = path.join(basePath, ".index.json");
 
+    let indexContent: string;
     try {
-        const indexContent = await fs.readFile(indexPath, "utf-8");
-        const index = parseIndex(indexContent, indexPath);
-
-        if (!index) return;
-
-        let missingCount = 0;
-        for (const file of index.files) {
-            if (!file.url) continue;
-
-            const filePath = path.join(basePath, file.filename);
-
-            if (!(await fileExists(filePath))) {
-                missingCount++;
-                continue;
-            }
-
-            const id = cache.referenceManager.generateId({
-                packageName: packageJson.name,
-                packageVersion: packageJson.version,
-                filePath,
-            });
-
-            cache.referenceManager.set(id, {
-                packageName: packageJson.name,
-                packageVersion: packageJson.version,
-                filePath,
-                resourceType: file.resourceType,
-                url: file.url,
-                version: file.version,
-            });
-
-            const entry: IndexEntry = {
-                id,
-                resourceType: file.resourceType,
-                indexVersion: index["index-version"],
-                url: file.url,
-                version: file.version,
-                kind: file.kind,
-                type: file.type,
-                package: {
-                    name: packageJson.name,
-                    version: packageJson.version,
-                },
-            };
-
-            if (!cache.entries[file.url]) {
-                cache.entries[file.url] = [];
-            }
-            const entries = cache.entries[file.url];
-            if (entries) {
-                entries.push(entry);
-            }
-        }
-
-        if (missingCount > 0) {
-            console.warn(
-                `Warning: ${packageJson.name}@${packageJson.version} .index.json references ${missingCount} file(s) not found on disk — index may be corrupt`,
-            );
-        }
+        indexContent = await fs.readFile(indexPath, "utf-8");
     } catch {
-        // Silently ignore index processing errors
+        return { result: { ok: false, reason: "unparseable" }, entries: [] };
+    }
+
+    const index = parseIndex(indexContent, indexPath);
+    if (!index) return { result: { ok: false, reason: "unparseable" }, entries: [] };
+
+    const entries: CollectedEntry[] = [];
+    let missingCount = 0;
+    for (const file of index.files) {
+        if (!file.url) continue;
+
+        const filePath = path.join(basePath, file.filename);
+        if (!(await fileExists(filePath))) {
+            missingCount++;
+            continue;
+        }
+
+        entries.push({
+            filePath,
+            resourceType: file.resourceType,
+            url: file.url,
+            version: file.version,
+            kind: file.kind,
+            type: file.type,
+            indexVersion: index["index-version"],
+        });
+    }
+
+    if (missingCount > 0) return { result: { ok: false, reason: "missing-files" }, entries };
+    return { result: { ok: true, count: entries.length }, entries };
+};
+
+/** Commit collected entries into the cache (reference manager + entry index). Returns the count. */
+export const commitEntries = (cache: ExtendedCache, packageJson: PackageJson, entries: CollectedEntry[]): number => {
+    for (const entry of entries) {
+        const id = cache.referenceManager.generateId({
+            packageName: packageJson.name,
+            packageVersion: packageJson.version,
+            filePath: entry.filePath,
+        });
+
+        cache.referenceManager.set(id, {
+            packageName: packageJson.name,
+            packageVersion: packageJson.version,
+            filePath: entry.filePath,
+            resourceType: entry.resourceType,
+            url: entry.url,
+            version: entry.version,
+        });
+
+        const indexEntry: IndexEntry = {
+            id,
+            resourceType: entry.resourceType,
+            indexVersion: entry.indexVersion,
+            url: entry.url,
+            version: entry.version,
+            kind: entry.kind,
+            type: entry.type,
+            package: { name: packageJson.name, version: packageJson.version },
+        };
+
+        if (!cache.entries[entry.url]) {
+            cache.entries[entry.url] = [];
+        }
+        cache.entries[entry.url]?.push(indexEntry);
+    }
+    return entries.length;
+};
+
+/**
+ * Committing wrapper over `collectFromIndex` — reads the index and commits its entries,
+ * warning on partial corruption (files referenced but missing on disk).
+ */
+export const processIndex = async (basePath: string, packageJson: PackageJson, cache: ExtendedCache): Promise<void> => {
+    const { result, entries } = await collectFromIndex(basePath);
+    commitEntries(cache, packageJson, entries);
+    if (!result.ok && result.reason === "missing-files") {
+        console.warn(
+            `Warning: ${packageJson.name}@${packageJson.version} .index.json references file(s) not found on disk — index may be corrupt`,
+        );
     }
 };

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -86,6 +86,16 @@ export type PreprocessContext = PreprocessPackageContext | PreprocessResourceCon
 
 export type PackageManager = "bun" | "npm";
 
+/**
+ * How to treat a package's shipped `.index.json`:
+ * - `"use"` (default): trust the shipped index; scan the directory only if it is absent.
+ *   A corrupt index is reported (warning) but not worked around.
+ * - `"recover"`: use the index, but fall back to a directory scan per-package if the
+ *   index is corrupt/incomplete (unparseable, or references files missing on disk).
+ * - `"regenerate"`: ignore shipped indexes and always scan the directory.
+ */
+export type PackageIndexMode = "use" | "recover" | "regenerate";
+
 export interface Config {
     packages: string[];
     workingDir: string;
@@ -95,7 +105,12 @@ export interface Config {
     packageManager?: PackageManager;
     /** Hook to preprocess packages and resources. Receives a discriminated union with `kind` field. */
     preprocessPackage?: (context: PreprocessContext) => PreprocessContext;
-    /** Ignore shipped .index.json files and force directory scanning for all packages. */
+    /** How to treat shipped `.index.json` files (default `"use"`). */
+    packageIndex?: PackageIndexMode;
+    /**
+     * @deprecated Use `packageIndex` instead (`true` → `"regenerate"`, `false` → `"use"`).
+     * Setting both `packageIndex` and `ignorePackageIndex` throws.
+     */
     ignorePackageIndex?: boolean;
 }
 

--- a/test/unit/manager/package-index.test.ts
+++ b/test/unit/manager/package-index.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { CanonicalManager } from "../../../src";
+
+describe("packageIndex config resolution", () => {
+    let workingDir: string;
+
+    beforeEach(async () => {
+        workingDir = await fs.mkdtemp(path.join(os.tmpdir(), "package-index-test-"));
+    });
+
+    afterEach(async () => {
+        await fs.rm(workingDir, { recursive: true, force: true }).catch(() => {});
+    });
+
+    test("throws when both packageIndex and ignorePackageIndex are set", async () => {
+        const manager = CanonicalManager({
+            packages: [],
+            workingDir,
+            packageIndex: "use",
+            ignorePackageIndex: true,
+        });
+        await expect(manager.init()).rejects.toThrow(/Cannot set both `packageIndex`/);
+    });
+
+    test("warns when the deprecated ignorePackageIndex is used", async () => {
+        const warnings: string[] = [];
+        const original = console.warn;
+        console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+        try {
+            const manager = CanonicalManager({ packages: [], workingDir, ignorePackageIndex: true });
+            // The deprecation warning fires synchronously at the top of init(); tolerate any
+            // later init hiccup (no packages installed) — we only assert the warning fired.
+            await manager.init().catch(() => {});
+        } finally {
+            console.warn = original;
+        }
+        expect(warnings.some((w) => w.includes("ignorePackageIndex") && w.includes("deprecated"))).toBe(true);
+    });
+
+    test("does not warn about deprecation when only packageIndex is set", async () => {
+        const warnings: string[] = [];
+        const original = console.warn;
+        console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+        try {
+            const manager = CanonicalManager({ packages: [], workingDir, packageIndex: "recover" });
+            await manager.init().catch(() => {});
+        } finally {
+            console.warn = original;
+        }
+        expect(warnings.some((w) => w.includes("ignorePackageIndex"))).toBe(false);
+    });
+});

--- a/test/unit/scanner/scanner.test.ts
+++ b/test/unit/scanner/scanner.test.ts
@@ -7,9 +7,9 @@ import {
     isValidFileEntry,
     isValidIndexFile,
     loadPackage,
+    loadPackagesIntoCache,
     parseIndex,
     processIndex,
-    scanDirectory,
 } from "../../../src/scanner";
 import type { PackageJson, PreprocessContext } from "../../../src/types";
 
@@ -326,7 +326,7 @@ describe("Scanner Module", () => {
             await fs.writeFile(path.join(packagePath, ".index.json"), JSON.stringify(indexContent));
             await touchFile(path.join(packagePath, "Patient.json"));
 
-            await loadPackage(packagePath, cache);
+            await loadPackage(packagePath, cache, { packageIndexMode: "use", preprocessPackage: (e) => e });
 
             // Check package info
             expect(cache.packages["hl7.fhir.test"]).toBeDefined();
@@ -384,7 +384,7 @@ describe("Scanner Module", () => {
             );
             await touchFile(path.join(examplesPath, "example.json"));
 
-            await loadPackage(packagePath, cache);
+            await loadPackage(packagePath, cache, { packageIndexMode: "use", preprocessPackage: (e) => e });
 
             expect(cache.entries["http://example.com/Profile"]).toHaveLength(1);
             expect(cache.entries["http://example.com/Patient/example"]).toHaveLength(1);
@@ -395,9 +395,132 @@ describe("Scanner Module", () => {
             const packagePath = path.join(tempDir, "invalid-package");
 
             // Should not throw
-            await loadPackage(packagePath, cache);
+            await loadPackage(packagePath, cache, { packageIndexMode: "use", preprocessPackage: (e) => e });
 
             expect(Object.keys(cache.packages)).toHaveLength(0);
+        });
+    });
+
+    describe("loadPackage packageIndex modes", () => {
+        const writeResource = (filePath: string, url: string) =>
+            fs.writeFile(filePath, JSON.stringify({ resourceType: "StructureDefinition", url, kind: "resource" }));
+
+        const writePackageJson = (packagePath: string) =>
+            fs.writeFile(
+                path.join(packagePath, "package.json"),
+                JSON.stringify({ name: "test.package", version: "1.0.0" }),
+            );
+
+        test('"regenerate" ignores the shipped index and scans the directory', async () => {
+            const cache = createCacheRecord();
+            const packagePath = path.join(tempDir, "pkg");
+            await fs.mkdir(packagePath, { recursive: true });
+            await writePackageJson(packagePath);
+
+            // Valid index that points at Ghost.json; plus a real on-disk resource not in the index.
+            await fs.writeFile(
+                path.join(packagePath, ".index.json"),
+                JSON.stringify({
+                    "index-version": 1,
+                    files: [
+                        {
+                            filename: "Ghost.json",
+                            resourceType: "StructureDefinition",
+                            id: "g",
+                            url: "http://ex/Ghost",
+                        },
+                    ],
+                }),
+            );
+            await touchFile(path.join(packagePath, "Ghost.json"));
+            await writeResource(path.join(packagePath, "Real.json"), "http://ex/Real");
+
+            await loadPackage(packagePath, cache, { packageIndexMode: "regenerate", preprocessPackage: (e) => e });
+
+            expect(cache.entries["http://ex/Real"]).toHaveLength(1); // scanned from disk
+            expect(cache.entries["http://ex/Ghost"]).toBeUndefined(); // shipped index ignored
+        });
+
+        test('"recover" falls back to a directory scan when the index is corrupt', async () => {
+            const cache = createCacheRecord();
+            const packagePath = path.join(tempDir, "pkg");
+            await fs.mkdir(packagePath, { recursive: true });
+            await writePackageJson(packagePath);
+
+            // Index references a file that does not exist on disk → "missing-files" corruption.
+            await fs.writeFile(
+                path.join(packagePath, ".index.json"),
+                JSON.stringify({
+                    "index-version": 1,
+                    files: [
+                        {
+                            filename: "Missing.json",
+                            resourceType: "StructureDefinition",
+                            id: "m",
+                            url: "http://ex/Missing",
+                        },
+                    ],
+                }),
+            );
+            await writeResource(path.join(packagePath, "Real.json"), "http://ex/Real");
+
+            await loadPackage(packagePath, cache, { packageIndexMode: "recover", preprocessPackage: (e) => e });
+
+            expect(cache.entries["http://ex/Real"]).toHaveLength(1); // recovered via scan
+            expect(cache.entries["http://ex/Missing"]).toBeUndefined();
+        });
+
+        test('"use" (default) does not recover a corrupt index and warns', async () => {
+            const cache = createCacheRecord();
+            const packagePath = path.join(tempDir, "pkg");
+            await fs.mkdir(packagePath, { recursive: true });
+            await writePackageJson(packagePath);
+
+            await fs.writeFile(
+                path.join(packagePath, ".index.json"),
+                JSON.stringify({
+                    "index-version": 1,
+                    files: [
+                        {
+                            filename: "Missing.json",
+                            resourceType: "StructureDefinition",
+                            id: "m",
+                            url: "http://ex/Missing",
+                        },
+                    ],
+                }),
+            );
+            await writeResource(path.join(packagePath, "Real.json"), "http://ex/Real");
+
+            const warnings: string[] = [];
+            const original = console.warn;
+            console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+            try {
+                await loadPackage(packagePath, cache, { packageIndexMode: "use", preprocessPackage: (e) => e });
+            } finally {
+                console.warn = original;
+            }
+
+            expect(cache.entries["http://ex/Real"]).toBeUndefined(); // no fallback scan in "use"
+            expect(warnings.some((w) => w.includes("missing-files"))).toBe(true); // but it warns
+        });
+
+        test("valid empty index (files: []) is not treated as corruption", async () => {
+            const cache = createCacheRecord();
+            const packagePath = path.join(tempDir, "pkg");
+            await fs.mkdir(packagePath, { recursive: true });
+            await writePackageJson(packagePath);
+
+            await fs.writeFile(
+                path.join(packagePath, ".index.json"),
+                JSON.stringify({ "index-version": 1, files: [] }),
+            );
+            await writeResource(path.join(packagePath, "Real.json"), "http://ex/Real");
+
+            await loadPackage(packagePath, cache, { packageIndexMode: "recover", preprocessPackage: (e) => e });
+
+            // Empty-but-valid index → ok/count:0 → no recover, so the on-disk file is NOT scanned in.
+            expect(cache.entries["http://ex/Real"]).toBeUndefined();
         });
     });
 
@@ -443,7 +566,7 @@ describe("Scanner Module", () => {
                 return ctx;
             };
 
-            await loadPackage(packagePath, cache, preprocessPackage);
+            await loadPackage(packagePath, cache, { packageIndexMode: "use", preprocessPackage });
 
             // Check that cache uses the fixed name
             expect(cache.packages["test.package"]).toBeDefined();
@@ -488,7 +611,7 @@ describe("Scanner Module", () => {
                 return { ...ctx, packageJson: { ...ctx.packageJson, name: "modified.name" } };
             };
 
-            await loadPackage(packagePath, cache, preprocessPackage);
+            await loadPackage(packagePath, cache, { packageIndexMode: "use", preprocessPackage });
 
             // Cache should have modified name
             expect(cache.packages["modified.name"]).toBeDefined();
@@ -501,7 +624,7 @@ describe("Scanner Module", () => {
         });
     });
 
-    describe("scanDirectory", () => {
+    describe("loadPackagesIntoCache", () => {
         test("should scan directory with FHIR packages", async () => {
             const cache = createCacheRecord();
             const nodeModules = path.join(tempDir, "node_modules");
@@ -538,7 +661,7 @@ describe("Scanner Module", () => {
                 JSON.stringify({ name: "regular.package", version: "1.0.0" }),
             );
 
-            await scanDirectory(cache, tempDir);
+            await loadPackagesIntoCache(cache, tempDir, { packageIndexMode: "use", preprocessPackage: (e) => e });
 
             expect(cache.packages["fhir.package1"]).toBeDefined();
             expect(cache.packages["regular.package"]).toBeDefined(); // All packages are registered now
@@ -573,7 +696,7 @@ describe("Scanner Module", () => {
             );
             await touchFile(path.join(packageDir, "Scoped.json"));
 
-            await scanDirectory(cache, tempDir);
+            await loadPackagesIntoCache(cache, tempDir, { packageIndexMode: "use", preprocessPackage: (e) => e });
 
             expect(cache.packages["@scope/package"]).toBeDefined();
             expect(cache.entries["http://example.com/Scoped"]).toHaveLength(1);


### PR DESCRIPTION
Replaces the `ignorePackageIndex` boolean with a tri-state `packageIndex` mode. Part of the Phase 0 foundation for atomic-ehr/codegen#128 (moving FHIR package defect-handling into CanonicalManager).

## Modes
- `"use"` (default): trust the shipped `.index.json`; **warn** on a corrupt index but don't work around it (surfaces today's previously-silent zero/partial loads).
- `"recover"`: use the index, but fall back to a **per-package** directory scan if it's corrupt/incomplete (unparseable, or references files missing on disk).
- `"regenerate"`: ignore shipped indexes and always scan (the old `ignorePackageIndex: true`).

## Backward compatibility
- `ignorePackageIndex` kept as a **deprecated alias** (`true` → `"regenerate"`, `false` → `"use"`) that warns when used.
- Setting **both** `packageIndex` and `ignorePackageIndex` throws.

## Internals
- `processIndex` refactored into a pure `collectFromIndex` (returns an `IndexLoadResult` + entries, no cache mutation) plus `commitEntries`, so `"recover"` can discard a partial index before scanning. `processIndex` is kept as a thin committing wrapper.
- A valid but empty index (`files: []`) is `{ ok, count: 0 }` — **not** treated as corruption (no spurious recover).

## Tests
- Scanner: `regenerate` ignores the index, `recover` falls back on a corrupt index, `use` does not recover (but warns), empty-but-valid index is not corruption.
- Manager: both-set throws, deprecation warning fires, `packageIndex`-only does not warn.

All 156 tests pass; typecheck + lint clean.