### PR TITLE
feat: composable patches, CM-level exclusion, and a diagnostics report

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A TypeScript package manager for FHIR resources that provides canonical URL reso
 - 🎯 **Flexible Search** - Search resources by type, kind, URL, version, or package
 - ⚡ **Performance Optimized** - In-memory cache with disk persistence
 - 🛠️ **TypeScript First** - Full TypeScript support with comprehensive types
+- 🩹 **Package Defect Handling** - Composable patches, canonical exclusion, index recovery, and a diagnostics report
 - 🖥️ **CLI Tool** - Command-line interface for package management and resource discovery
 
 ## Installation
@@ -292,9 +293,16 @@ Creates a new instance of the canonical manager.
 
 ```typescript
 interface Config {
-  packages: string[];      // FHIR packages to install (e.g., ["hl7.fhir.r4.core"])
-  workingDir: string;      // Directory for packages and cache
-  registry?: string;       // NPM registry URL (optional)
+  packages: string[];               // FHIR packages to install (e.g., ["hl7.fhir.r4.core"])
+  workingDir: string;               // Directory for packages and cache
+  registry?: string;                // NPM registry URL (optional)
+  dropCache?: boolean;              // Rebuild the cache instead of loading it from disk
+  patches?: Partial<Patches>;       // Per-phase handler lists (see "Patches & defect handling")
+  packageIndex?: PackageIndexMode;  // How to treat shipped .index.json files (default "use")
+  /** @deprecated use `patches` — equivalent to package/resource handlers */
+  preprocessPackage?: (ctx: PreprocessContext) => PreprocessContext;
+  /** @deprecated use `packageIndex` */
+  ignorePackageIndex?: boolean;
 }
 ```
 
@@ -309,6 +317,90 @@ const manager = CanonicalManager({
     registry: "https://fs.get-ig.org/pkgs/"
 });
 ```
+
+### Patches & defect handling
+
+Real-world FHIR packages ship defects (missing dependencies, canonical URL typos,
+unavailable ValueSet bindings, cross-version type references, corrupt `.index.json`).
+CanonicalManager exposes three knobs to work around them.
+
+#### `packageIndex` — how to treat shipped `.index.json`
+
+```typescript
+type PackageIndexMode = "use" | "recover" | "regenerate";
+```
+
+- **`"use"`** (default): trust the shipped index; scan the directory only if it's
+  absent. A corrupt index is **warned** about but not worked around (matches prior behavior).
+- **`"recover"`**: use the index, but fall back to a **per-package** directory scan when
+  it's corrupt or incomplete (unparseable, or references files missing on disk).
+- **`"regenerate"`**: ignore shipped indexes and always scan.
+
+`ignorePackageIndex` is a deprecated alias (`true` → `"regenerate"`, `false` → `"use"`);
+setting both it and `packageIndex` throws.
+
+#### `patches` — composable transforms and exclusions
+
+`patches` is a single `Patches` object with an optional **list of handlers per phase** —
+`package`, `entry`, and `resource`. Each handler receives its package id, the value being
+patched (`packageJson` / `entry` / `resource`), and a diagnostics sink, and returns a
+transformed value or `undefined` to no-op; the handlers in a phase run left-to-right. The
+`entry` handlers may also return `null` to **drop** the canonical (it never enters the
+index). Provide only the phases you need; the deprecated `preprocessPackage` is appended
+after your package/resource handlers.
+
+```typescript
+import type { PackagePatch } from "@atomic-ehr/fhir-canonical-manager";
+
+// A handler is (pkg, value, report) => transformedValue | undefined.
+// Fix a package's declared version at the package phase:
+const fixVersion: PackagePatch = (pkg, packageJson) => ({ ...packageJson, version: "1.2.3" });
+
+// patches: { package: [fixVersion] }
+```
+
+The bundled patch helpers (`excludeCanonical`, `applyPatches`, `matchPackage`) are exported
+from the `@atomic-ehr/fhir-canonical-manager/patch` subpath. `excludeCanonical` returns an
+`entry` handler that drops a canonical (e.g. an R4 extension that references an R5-only type):
+
+```typescript
+import { CanonicalManager } from "@atomic-ehr/fhir-canonical-manager";
+import { excludeCanonical } from "@atomic-ehr/fhir-canonical-manager/patch";
+
+const manager = CanonicalManager({
+    packages: ["hl7.fhir.uv.extensions.r4"],
+    workingDir: "./fhir-packages",
+    patches: {
+        entry: [
+            excludeCanonical({
+                url: "http://hl7.org/fhir/StructureDefinition/specimen-additive",
+                reason: "Uses CodeableReference, not available in R4",
+            }),
+        ],
+    },
+});
+```
+
+> **Caching note:** exclusions and package-level transforms are baked into the on-disk
+> cache when the index is built. If you change `patches` between runs, set
+> `dropCache: true` (or clear the working dir) so the change takes effect.
+
+#### `report()` — why you see what you see
+
+```typescript
+const report = manager.report(); // ReportEntry[]
+//   { kind: "index-recovery"; package; reason; recovered }
+//   | { kind: "exclusion"; package; url; reason }
+//   | { kind: "deprecation"; message }
+```
+
+Returns a record of every defect-handling action taken (index recoveries, exclusions,
+deprecation notices), so downstream tools can explain why a canonical is missing or changed.
+
+> **Cached-run caveat:** these actions are recorded only while **building** the index. On a
+> cached run the outcomes are already baked into the cache, so `report()` returns nothing for
+> them — exactly when you might ask "why is X missing." Use `dropCache: true` to rebuild and
+> repopulate the report.
 
 ### `init(): Promise<void>`
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./patch": {
+      "types": "./dist/patches.d.ts",
+      "import": "./dist/patches.js",
+      "default": "./dist/patches.js"
     }
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@
 
 // Re-export main CanonicalManager factory and class
 export { CanonicalManager, createCanonicalManager } from "./manager/index.js";
+// Composable patches are exposed via the "@atomic-ehr/fhir-canonical-manager/patch" subpath (src/patches.ts).
 export type { ReferenceManager as ReferenceManagerType } from "./reference.js";
 // Re-export reference management
 export { createReferenceManager, ReferenceManagerFactory as ReferenceManager } from "./reference.js";

--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -17,6 +17,7 @@ import { DEFAULT_REGISTRY } from "../constants.js";
 import { ensureDir, fileExists } from "../fs/index.js";
 import { installLocalFolder, installTgzPackage } from "../local.js";
 import { detectPackageManager, installPackages } from "../package.js";
+import { applyPatches } from "../patches.js";
 import { resolveWithContext } from "../resolver.js";
 import { loadPackagesIntoCache } from "../scanner/index.js";
 import { filterBySmartSearch } from "../search/index.js";
@@ -29,7 +30,10 @@ import type {
     PackageIndexMode,
     PackageInfo,
     PackageJson,
+    Patches,
+    PatchReportSink,
     Reference,
+    ReportEntry,
     Resource,
     SearchParameter,
     SourceContext,
@@ -54,6 +58,42 @@ const resolvePackageIndexMode = (config: Config): PackageIndexMode => {
         '`ignorePackageIndex` is deprecated; use `packageIndex` instead ("regenerate" replaces `true`, "use" replaces `false`).',
     );
     return config.ignorePackageIndex ? "regenerate" : "use";
+};
+
+/** A diagnostics sink plus the backing entries array exposed via `report()`. */
+const createReportSink = (): { sink: PatchReportSink; entries: ReportEntry[] } => {
+    const entries: ReportEntry[] = [];
+    return {
+        entries,
+        sink: (entry) => {
+            entries.push(entry);
+        },
+    };
+};
+
+/** Compose `config.patches` (and the deprecated `preprocessPackage`, last) into one effective patch. */
+const resolveEffectivePatch = (config: Config): Patches => {
+    const configured = config.patches ?? {};
+    const patches: Patches = {
+        package: [...(configured.package ?? [])],
+        entry: [...(configured.entry ?? [])],
+        resource: [...(configured.resource ?? [])],
+    };
+    if (config.preprocessPackage) {
+        const legacy = config.preprocessPackage;
+        // The legacy hook predates per-phase handlers: it takes a kind-tagged PreprocessContext
+        // and only transforms packages/resources. Bridge it — add `kind` going in, strip it (and
+        // guard against a wrong-kind return) coming out — as package/resource handlers.
+        patches.package.push((pkg, packageJson) => {
+            const r = legacy({ kind: "package", package: pkg, packageJson });
+            return r.kind === "package" ? r.packageJson : undefined;
+        });
+        patches.resource.push((pkg, resource) => {
+            const r = legacy({ kind: "resource", package: pkg, resource });
+            return r.kind === "resource" ? r.resource : undefined;
+        });
+    }
+    return patches;
 };
 
 interface LocalPackageEntry {
@@ -157,6 +197,10 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
     let initialized = false;
     const searchParamsCache = new Map<string, SearchParameter[]>();
 
+    // Composed patch + de-duped diagnostics sink, built once and used at all three phases.
+    const { sink: reportSink, entries: reportEntries } = createReportSink();
+    const effectivePatches = resolveEffectivePatch(config);
+
     const installConfiguredLocalPackages = async (npmPackagePath: string): Promise<void> => {
         const skipDependencyInstall = process.env.FCM_SKIP_LOCAL_DEP_INSTALL === "1";
         for (const entry of localPackages.values()) {
@@ -257,6 +301,12 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
 
         // Validate + resolve up front so the both-set error / deprecation fires regardless of cache state.
         const packageIndexMode = resolvePackageIndexMode(config);
+        if (config.ignorePackageIndex !== undefined) {
+            reportSink({
+                kind: "deprecation",
+                message: "`ignorePackageIndex` is deprecated; use `packageIndex`.",
+            });
+        }
 
         await refreshLocalPackageCacheKeys();
         await ensureDir(workingDir);
@@ -298,7 +348,8 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
             await installConfiguredLocalPackages(npmPackagePath);
             await loadPackagesIntoCache(cache, npmPackagePath, {
                 packageIndexMode,
-                preprocessPackage: config.preprocessPackage ?? ((e) => e),
+                patches: effectivePatches,
+                report: reportSink,
             });
             await saveCacheRecordToDisk(cache, workingDir, packageManager, getCacheKeyPackages());
         }
@@ -415,16 +466,13 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
                 resourceType: reference.resourceType,
             };
 
-            if (config.preprocessPackage) {
-                const result = config.preprocessPackage({
-                    kind: "resource",
-                    resource,
-                    package: { name: metadata.packageName, version: metadata.packageVersion },
-                });
-                if (result.kind === "resource") {
-                    resource = result.resource;
-                }
-            }
+            const result = applyPatches(
+                effectivePatches.resource,
+                { name: metadata.packageName, version: metadata.packageVersion },
+                resource,
+                reportSink,
+            );
+            if (result) resource = result;
 
             return resource;
         } catch (err) {
@@ -628,5 +676,6 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
         smartSearch,
         getSearchParametersForResource,
         packageJson,
+        report: (): ReportEntry[] => [...reportEntries],
     };
 };

--- a/src/patches.ts
+++ b/src/patches.ts
@@ -1,0 +1,47 @@
+/**
+ * Composable patches: transform/filter packages, index entries, and resources.
+ */
+
+import type { EntryPatch, IndexEntry, PackageId, PatchReportSink, Resource } from "./types/index.js";
+
+/** Match a package by exact name, name+version, or a predicate. */
+export type PackageMatch = string | { name: string; version?: string } | ((pkg: PackageId) => boolean);
+
+export const matchPackage = (match: PackageMatch, pkg: PackageId): boolean => {
+    if (typeof match === "function") return match(pkg);
+    if (typeof match === "string") return pkg.name === match;
+    return pkg.name === match.name && (match.version === undefined || pkg.version === match.version);
+};
+
+/**
+ * Run a phase's handlers left-to-right over a value (`packageJson` / `entry` / `resource`).
+ * `undefined` is a no-op (keeps the accumulated value); at the `entry` phase a handler may
+ * return `null` to drop the canonical, short-circuiting the rest and returning `null`.
+ */
+export const applyPatches = <T extends Record<string, unknown> | IndexEntry | Resource>(
+    handlers: ((pkg: PackageId, value: T, report: PatchReportSink) => T | null | undefined)[] | undefined,
+    pkg: PackageId,
+    value: T,
+    report: PatchReportSink,
+): T | null => {
+    let acc = value;
+    for (const handler of handlers ?? []) {
+        const result = handler(pkg, acc, report);
+        if (result === null) return null;
+        if (result !== undefined) acc = result;
+    }
+    return acc;
+};
+
+/**
+ * An entry-phase handler that drops a canonical from the index: returns `null` when the URL
+ * (and optional package) match, recording the reason in the report; otherwise no-op.
+ */
+export const excludeCanonical =
+    (opts: { package?: PackageMatch; url: string; reason: string }): EntryPatch =>
+    (pkg, entry, report) => {
+        if (entry.url !== opts.url) return undefined;
+        if (opts.package && !matchPackage(opts.package, pkg)) return undefined;
+        report({ kind: "exclusion", package: pkg, url: opts.url, reason: opts.reason });
+        return null;
+    };

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -3,6 +3,6 @@
  */
 
 export { loadPackagesIntoCache } from "./directory.js";
-export { loadPackage } from "./package.js";
+export { loadPackage, type ScanOptions } from "./package.js";
 export { isValidFileEntry, isValidIndexFile, parseIndex } from "./parser.js";
 export { processIndex } from "./processor.js";

--- a/src/scanner/package.ts
+++ b/src/scanner/package.ts
@@ -6,73 +6,9 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ExtendedCache } from "../cache.js";
 import { fileExists } from "../fs/index.js";
-import type { IndexEntry, PackageIndexMode, PackageJson, PreprocessContext } from "../types/index.js";
-import { collectFromIndex, commitEntries } from "./processor.js";
-
-const scanDirectoryForResources = async (
-    dirPath: string,
-    packageJson: PackageJson,
-    cache: ExtendedCache,
-): Promise<number> => {
-    let count = 0;
-    try {
-        const entries = await fs.readdir(dirPath, { withFileTypes: true });
-
-        for (const entry of entries) {
-            if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
-            if (entry.name === "package.json" || entry.name === ".index.json") continue;
-
-            const filePath = path.join(dirPath, entry.name);
-
-            try {
-                const content = await fs.readFile(filePath, "utf-8");
-                const resource = JSON.parse(content);
-
-                if (!resource.resourceType || !resource.url) continue;
-
-                const id = cache.referenceManager.generateId({
-                    packageName: packageJson.name,
-                    packageVersion: packageJson.version,
-                    filePath,
-                });
-
-                cache.referenceManager.set(id, {
-                    packageName: packageJson.name,
-                    packageVersion: packageJson.version,
-                    filePath,
-                    resourceType: resource.resourceType,
-                    url: resource.url,
-                    version: resource.version,
-                });
-
-                const indexEntry: IndexEntry = {
-                    id,
-                    resourceType: resource.resourceType,
-                    indexVersion: 0,
-                    url: resource.url,
-                    version: resource.version,
-                    kind: resource.kind,
-                    type: resource.type,
-                    package: {
-                        name: packageJson.name,
-                        version: packageJson.version,
-                    },
-                };
-
-                if (!cache.entries[resource.url]) {
-                    cache.entries[resource.url] = [];
-                }
-                cache.entries[resource.url]?.push(indexEntry);
-                count++;
-            } catch {
-                // Skip files that can't be parsed
-            }
-        }
-    } catch {
-        // Silently ignore directory scan errors
-    }
-    return count;
-};
+import { applyPatches } from "../patches.js";
+import type { PackageIndexMode, PackageJson, Patches, PatchReportSink } from "../types/index.js";
+import { collectFromDirectory, collectFromIndex, commitEntries } from "./processor.js";
 
 const CORE_PACKAGE_PATTERN = /^hl7\.fhir\.r\d+\.core$/;
 
@@ -83,28 +19,34 @@ const hasCorePackageDependency = (dependencies: Record<string, string> | undefin
     return Object.keys(dependencies).some(isCorePackage);
 };
 
-/** Options for scanning a package into the cache. The mode is resolved by the caller. */
+/** Options for scanning a package into the cache. The mode and composed patches are resolved by the caller. */
 export type ScanOptions = {
     packageIndexMode: PackageIndexMode;
-    preprocessPackage: (context: PreprocessContext) => PreprocessContext;
+    /** Composed patches (transforms + exclusions), applied at the package, entry, and resource phases. */
+    patches: Patches;
+    /** Diagnostics sink for patch/recovery/exclusion reasons. */
+    report: PatchReportSink;
 };
 
 /**
  * Load a package's resources into the cache: use the shipped index, scan the directory,
  * or recover (scan when the index is corrupt). Returns the committed count and whether
- * the shipped index was used (drives the "no .index.json" diagnostic).
+ * the shipped index was used (drives the "no .index.json" diagnostic). `patches` runs at the
+ * entry phase per candidate (a `null` return excludes it).
  */
 const loadResources = async (
     packagePath: string,
     packageJson: PackageJson,
     cache: ExtendedCache,
     mode: PackageIndexMode,
+    patches: Patches,
+    report: PatchReportSink,
 ): Promise<{ count: number; usedIndex: boolean }> => {
     const pkgId = `${packageJson.name}@${packageJson.version}`;
 
     // No usable shipped index → scan the directory.
     if (mode === "regenerate" || !(await fileExists(path.join(packagePath, ".index.json")))) {
-        const count = await scanDirectoryForResources(packagePath, packageJson, cache);
+        const count = commitEntries(cache, packageJson, await collectFromDirectory(packagePath), patches, report);
         if (count > 0) {
             console.warn(`Warning: index generated for ${packageJson.name} (${count} resources)`);
         }
@@ -117,9 +59,16 @@ const loadResources = async (
     if (!result.ok) {
         if (mode === "recover") {
             console.warn(`Recovered ${pkgId}: .index.json is ${result.reason}; scanning directory instead.`);
-            return { count: await scanDirectoryForResources(packagePath, packageJson, cache), usedIndex: false };
+            const count = commitEntries(cache, packageJson, await collectFromDirectory(packagePath), patches, report);
+            report({
+                kind: "index-recovery",
+                package: { name: packageJson.name, version: packageJson.version },
+                reason: result.reason,
+                recovered: count,
+            });
+            return { count, usedIndex: false };
         }
-        const count = commitEntries(cache, packageJson, entries);
+        const count = commitEntries(cache, packageJson, entries, patches, report);
         console.warn(
             `Warning: ${pkgId} .index.json is ${result.reason}; loaded ${count} resource(s). ` +
                 `Set packageIndex: "recover" to fall back to a directory scan.`,
@@ -128,10 +77,10 @@ const loadResources = async (
     }
 
     // Usable shipped index (plus any examples index).
-    let count = commitEntries(cache, packageJson, entries);
+    let count = commitEntries(cache, packageJson, entries, patches, report);
     const examplesPath = path.join(packagePath, "examples");
     if (await fileExists(path.join(examplesPath, ".index.json"))) {
-        count += commitEntries(cache, packageJson, (await collectFromIndex(examplesPath)).entries);
+        count += commitEntries(cache, packageJson, (await collectFromIndex(examplesPath)).entries, patches, report);
     }
     return { count, usedIndex: true };
 };
@@ -145,7 +94,7 @@ export const loadPackage = async (
     cache: ExtendedCache,
     options: ScanOptions,
 ): Promise<string | undefined> => {
-    const { packageIndexMode: mode, preprocessPackage } = options;
+    const { packageIndexMode: mode, patches, report } = options;
 
     const packageJsonPath = path.join(packagePath, "package.json");
     if (!(await fileExists(packageJsonPath))) return undefined;
@@ -154,12 +103,8 @@ export const loadPackage = async (
     try {
         const content = await fs.readFile(packageJsonPath, "utf-8");
         let parsed = JSON.parse(content);
-        const result = preprocessPackage({
-            kind: "package",
-            packageJson: parsed,
-            package: { name: parsed.name, version: parsed.version },
-        });
-        if (result.kind === "package") parsed = result.packageJson;
+        const result = applyPatches(patches.package, { name: parsed.name, version: parsed.version }, parsed, report);
+        if (result) parsed = result;
         packageJson = parsed as PackageJson;
     } catch {
         return undefined;
@@ -174,7 +119,7 @@ export const loadPackage = async (
         packageJson,
     };
 
-    const { count, usedIndex } = await loadResources(packagePath, packageJson, cache, mode);
+    const { count, usedIndex } = await loadResources(packagePath, packageJson, cache, mode, patches, report);
 
     // No resources = not a FHIR package, no warning needed
     if (count === 0) return undefined;

--- a/src/scanner/processor.ts
+++ b/src/scanner/processor.ts
@@ -6,7 +6,8 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { ExtendedCache } from "../cache.js";
 import { fileExists } from "../fs/index.js";
-import type { IndexEntry, PackageJson } from "../types/index.js";
+import { applyPatches } from "../patches.js";
+import type { IndexEntry, PackageJson, Patches, PatchReportSink } from "../types/index.js";
 import { parseIndex } from "./parser.js";
 
 /** A resource discovered from an index or directory scan, not yet committed to the cache. */
@@ -69,8 +70,59 @@ export const collectFromIndex = async (
     return { result: { ok: true, count: entries.length }, entries };
 };
 
-/** Commit collected entries into the cache (reference manager + entry index). Returns the count. */
-export const commitEntries = (cache: ExtendedCache, packageJson: PackageJson, entries: CollectedEntry[]): number => {
+/**
+ * Read FHIR resources directly from a directory (no `.index.json`), collecting entries
+ * **without** mutating the cache. Files without `resourceType`/`url` or that fail to
+ * parse are skipped.
+ */
+export const collectFromDirectory = async (dirPath: string): Promise<CollectedEntry[]> => {
+    const entries: CollectedEntry[] = [];
+
+    try {
+        const dirents = await fs.readdir(dirPath, { withFileTypes: true });
+        for (const dirent of dirents) {
+            if (!dirent.isFile() || !dirent.name.endsWith(".json")) continue;
+            if (dirent.name === "package.json" || dirent.name === ".index.json") continue;
+
+            const filePath = path.join(dirPath, dirent.name);
+            try {
+                const resource = JSON.parse(await fs.readFile(filePath, "utf-8"));
+                if (!resource.resourceType || !resource.url) continue;
+                entries.push({
+                    filePath,
+                    resourceType: resource.resourceType,
+                    url: resource.url,
+                    version: resource.version,
+                    kind: resource.kind,
+                    type: resource.type,
+                    indexVersion: 0,
+                });
+            } catch {
+                // Skip files that can't be parsed
+            }
+        }
+    } catch {
+        // Silently ignore directory scan errors
+    }
+
+    return entries;
+};
+
+/**
+ * Commit collected entries into the cache (reference manager + entry index). Returns the
+ * committed count. When `patches` is provided, it runs at the entry phase per candidate:
+ * a `null` return excludes the canonical (never registered or indexed), and a returned
+ * `entry` context replaces the index metadata that gets committed.
+ */
+export const commitEntries = (
+    cache: ExtendedCache,
+    packageJson: PackageJson,
+    entries: CollectedEntry[],
+    patches?: Patches,
+    report?: PatchReportSink,
+): number => {
+    const pkg = { name: packageJson.name, version: packageJson.version };
+    let committed = 0;
     for (const entry of entries) {
         const id = cache.referenceManager.generateId({
             packageName: packageJson.name,
@@ -78,16 +130,7 @@ export const commitEntries = (cache: ExtendedCache, packageJson: PackageJson, en
             filePath: entry.filePath,
         });
 
-        cache.referenceManager.set(id, {
-            packageName: packageJson.name,
-            packageVersion: packageJson.version,
-            filePath: entry.filePath,
-            resourceType: entry.resourceType,
-            url: entry.url,
-            version: entry.version,
-        });
-
-        const indexEntry: IndexEntry = {
+        let indexEntry: IndexEntry = {
             id,
             resourceType: entry.resourceType,
             indexVersion: entry.indexVersion,
@@ -95,15 +138,34 @@ export const commitEntries = (cache: ExtendedCache, packageJson: PackageJson, en
             version: entry.version,
             kind: entry.kind,
             type: entry.type,
-            package: { name: packageJson.name, version: packageJson.version },
+            package: pkg,
         };
 
-        if (!cache.entries[entry.url]) {
-            cache.entries[entry.url] = [];
+        if (patches?.entry.length && report) {
+            const result = applyPatches(patches.entry, pkg, indexEntry, report);
+            if (result === null) continue; // excluded — never registered or indexed
+            indexEntry = result;
         }
-        cache.entries[entry.url]?.push(indexEntry);
+
+        // A url-less entry can't be resolved by canonical URL; if a transform cleared `url`,
+        // skip the whole commit so we never register/count an entry absent from the url index.
+        const url = indexEntry.url;
+        if (!url) continue;
+
+        cache.referenceManager.set(id, {
+            packageName: packageJson.name,
+            packageVersion: packageJson.version,
+            filePath: entry.filePath,
+            resourceType: indexEntry.resourceType,
+            url,
+            version: indexEntry.version,
+        });
+
+        if (!cache.entries[url]) cache.entries[url] = [];
+        cache.entries[url]?.push(indexEntry);
+        committed++;
     }
-    return entries.length;
+    return committed;
 };
 
 /**

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -68,21 +68,55 @@ export interface SourceContext {
     path?: string;
 }
 
-export type PreprocessBaseContext = {
-    package: PackageId;
-};
+/**
+ * @deprecated Use `patches` (per-phase handlers). Kind-discriminated context for the legacy
+ * `preprocessPackage` hook; only the package and resource phases are surfaced to it.
+ */
+export type PreprocessContext =
+    | { kind: "package"; package: PackageId; packageJson: Record<string, unknown> }
+    | { kind: "resource"; package: PackageId; resource: Resource };
 
-export type PreprocessPackageContext = PreprocessBaseContext & {
-    kind: "package";
-    packageJson: Record<string, unknown>;
-};
+/** A structured record of a defect-handling action CM took (returned by `report()`). */
+export type ReportEntry =
+    | {
+          kind: "index-recovery";
+          package: PackageId;
+          reason: "unparseable" | "missing-files";
+          recovered: number;
+      }
+    | { kind: "exclusion"; package: PackageId; url: string; reason: string }
+    | { kind: "deprecation"; message: string };
 
-export type PreprocessResourceContext = PreprocessBaseContext & {
-    kind: "resource";
-    resource: Resource;
-};
+/** Diagnostics sink passed to patches as their second argument. */
+export type PatchReportSink = (entry: ReportEntry) => void;
 
-export type PreprocessContext = PreprocessPackageContext | PreprocessResourceContext;
+/** Patch handler for the package phase: transform the package.json, or no-op (`undefined`). */
+export type PackagePatch = (
+    pkg: PackageId,
+    packageJson: Record<string, unknown>,
+    report: PatchReportSink,
+) => Record<string, unknown> | undefined;
+
+/** Patch handler for the index-entry phase: transform the entry, drop it (`null`), or no-op. */
+export type EntryPatch = (pkg: PackageId, entry: IndexEntry, report: PatchReportSink) => IndexEntry | null | undefined;
+
+/** Patch handler for the resource phase: transform the resource, or no-op (`undefined`). */
+export type ResourcePatch = (pkg: PackageId, resource: Resource, report: PatchReportSink) => Resource | undefined;
+
+/**
+ * A composable set of transform/filter handlers applied to packages, index entries, and
+ * resources. Each phase holds a list of handlers run left-to-right; each handler receives
+ * its package id, the value being patched (`packageJson` / `entry` / `resource`), and a
+ * diagnostics sink, and returns a transformed value or `undefined` for no-op. Drop (`null`)
+ * is available **only** at the `entry` phase. This is the normalized form (every phase
+ * present); `Config.patches` accepts a `Partial<Patches>`, so callers provide only the
+ * phase(s) they care about.
+ */
+export type Patches = {
+    package: PackagePatch[];
+    entry: EntryPatch[];
+    resource: ResourcePatch[];
+};
 
 export type PackageManager = "bun" | "npm";
 
@@ -105,6 +139,8 @@ export interface Config {
     packageManager?: PackageManager;
     /** Hook to preprocess packages and resources. Receives a discriminated union with `kind` field. */
     preprocessPackage?: (context: PreprocessContext) => PreprocessContext;
+    /** Composable patch handlers applied to packages, index entries, and resources (run before `preprocessPackage`). */
+    patches?: Partial<Patches>;
     /** How to treat shipped `.index.json` files (default `"use"`). */
     packageIndex?: PackageIndexMode;
     /**
@@ -199,4 +235,11 @@ export interface CanonicalManager {
     ): Promise<IndexEntry[]>;
     getSearchParametersForResource(resourceType: string): Promise<SearchParameter[]>;
     packageJson(packageName: string): Promise<PackageJson>;
+    /**
+     * Structured record of defect-handling actions (index recoveries, exclusions, deprecation
+     * notices). These are emitted only while **building** the index; on a cached run the actions
+     * are already baked into the cache, so `report()` returns nothing for them — set
+     * `dropCache: true` to rebuild and repopulate the report.
+     */
+    report(): ReportEntry[];
 }

--- a/test/unit/manager/exclusion.test.ts
+++ b/test/unit/manager/exclusion.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { CanonicalManager } from "../../../src";
+import { excludeCanonical } from "../../../src/patches";
+
+describe("CM-level exclusion", () => {
+    let root: string;
+
+    beforeEach(async () => {
+        root = await fs.mkdtemp(path.join(os.tmpdir(), "exclusion-test-"));
+    });
+
+    afterEach(async () => {
+        await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+    });
+
+    test("an excluded canonical is absent from the index and reported", async () => {
+        const pkgPath = path.join(root, "pkg");
+        await fs.mkdir(pkgPath, { recursive: true });
+        await fs.writeFile(
+            path.join(pkgPath, "package.json"),
+            JSON.stringify({ name: "test.package", version: "1.0.0" }),
+        );
+        await fs.writeFile(
+            path.join(pkgPath, ".index.json"),
+            JSON.stringify({
+                "index-version": 1,
+                files: [
+                    { filename: "Good.json", resourceType: "StructureDefinition", id: "g", url: "http://ex/Good" },
+                    { filename: "Bad.json", resourceType: "StructureDefinition", id: "b", url: "http://ex/Bad" },
+                ],
+            }),
+        );
+        await fs.writeFile(
+            path.join(pkgPath, "Good.json"),
+            JSON.stringify({ resourceType: "StructureDefinition", id: "g", url: "http://ex/Good" }),
+        );
+        await fs.writeFile(
+            path.join(pkgPath, "Bad.json"),
+            JSON.stringify({ resourceType: "StructureDefinition", id: "b", url: "http://ex/Bad" }),
+        );
+
+        const manager = CanonicalManager({
+            packages: [],
+            workingDir: path.join(root, "wd"),
+            patches: { entry: [excludeCanonical({ url: "http://ex/Bad", reason: "cross-version type" })] },
+        });
+        await manager.addLocalPackage({ name: "test.package", version: "1.0.0", path: pkgPath });
+        await manager.init();
+
+        // Consistent across the metadata and resource query surfaces.
+        expect(await manager.searchEntries({ url: "http://ex/Bad" })).toHaveLength(0);
+        expect(await manager.searchEntries({ url: "http://ex/Good" })).toHaveLength(1);
+        await expect(manager.resolve("http://ex/Bad")).rejects.toThrow();
+        expect((await manager.resolve("http://ex/Good")).url).toBe("http://ex/Good");
+
+        // The exclusion (with its reason) shows up in the diagnostics report.
+        const report = manager.report();
+        expect(report.some((e) => e.kind === "exclusion" && e.url === "http://ex/Bad")).toBe(true);
+    });
+});

--- a/test/unit/patches/patches.test.ts
+++ b/test/unit/patches/patches.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { applyPatches, excludeCanonical, matchPackage } from "../../../src/patches";
+import type { EntryPatch, IndexEntry, PackagePatch, PatchReportSink, ReportEntry } from "../../../src/types";
+
+const mkSink = (): { report: PatchReportSink; entries: ReportEntry[] } => {
+    const entries: ReportEntry[] = [];
+    return { report: (e) => entries.push(e), entries };
+};
+
+const pkg = { name: "p", version: "1" };
+const entry = (url: string): IndexEntry => ({ id: "x", resourceType: "StructureDefinition", indexVersion: 0, url });
+
+describe("applyPatches", () => {
+    test("applies handlers left-to-right", () => {
+        const h1: PackagePatch = (_pkg, packageJson) => ({ ...packageJson, a: 1 });
+        const h2: PackagePatch = (_pkg, packageJson) => ({ ...packageJson, b: 2 });
+        const { report } = mkSink();
+        const out = applyPatches([h1, h2], pkg, {}, report);
+        expect(out).toEqual({ a: 1, b: 2 });
+    });
+
+    test("null at the entry phase short-circuits and skips later handlers", () => {
+        let called = false;
+        const drop: EntryPatch = () => null;
+        const after: EntryPatch = () => {
+            called = true;
+            return undefined;
+        };
+        const { report } = mkSink();
+        expect(applyPatches([drop, after], pkg, entry("u"), report)).toBeNull();
+        expect(called).toBe(false);
+    });
+
+    test("undefined is a no-op (keeps the accumulated value)", () => {
+        const noop: EntryPatch = () => undefined;
+        const { report } = mkSink();
+        const e = entry("u");
+        expect(applyPatches([noop], pkg, e, report)).toBe(e);
+    });
+
+    test("no handlers is a no-op", () => {
+        const { report } = mkSink();
+        const e = entry("u");
+        expect(applyPatches(undefined, pkg, e, report)).toBe(e);
+    });
+});
+
+describe("excludeCanonical", () => {
+    test("drops a matching entry and notes the report", () => {
+        const { report, entries } = mkSink();
+        const result = excludeCanonical({ url: "http://ex/Bad", reason: "R5 type" })(
+            pkg,
+            entry("http://ex/Bad"),
+            report,
+        );
+        expect(result).toBeNull();
+        expect(entries).toEqual([{ kind: "exclusion", package: pkg, url: "http://ex/Bad", reason: "R5 type" }]);
+    });
+
+    test("no-ops on a non-matching url", () => {
+        const { report, entries } = mkSink();
+        const patch = excludeCanonical({ url: "http://ex/Bad", reason: "x" });
+        expect(patch(pkg, entry("http://ex/Good"), report)).toBeUndefined();
+        expect(entries).toHaveLength(0);
+    });
+
+    test("respects the package filter", () => {
+        const { report } = mkSink();
+        const patch = excludeCanonical({ package: "other", url: "http://ex/Bad", reason: "x" });
+        expect(patch(pkg, entry("http://ex/Bad"), report)).toBeUndefined();
+    });
+});
+
+describe("matchPackage", () => {
+    test("matches by string, object, and predicate", () => {
+        expect(matchPackage("p", pkg)).toBe(true);
+        expect(matchPackage("q", pkg)).toBe(false);
+        expect(matchPackage({ name: "p" }, pkg)).toBe(true);
+        expect(matchPackage({ name: "p", version: "2" }, pkg)).toBe(false);
+        expect(matchPackage((x) => x.version === "1", pkg)).toBe(true);
+    });
+});

--- a/test/unit/scanner/scanner.test.ts
+++ b/test/unit/scanner/scanner.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { createCacheRecord } from "../../../src/cache";
+import { excludeCanonical } from "../../../src/patches";
 import {
     isValidFileEntry,
     isValidIndexFile,
@@ -10,11 +11,26 @@ import {
     loadPackagesIntoCache,
     parseIndex,
     processIndex,
+    type ScanOptions,
 } from "../../../src/scanner";
-import type { PackageJson, PreprocessContext } from "../../../src/types";
+import type { PackageIndexMode, PackageJson, Patches, PatchReportSink, ReportEntry } from "../../../src/types";
 
 /** Write an empty stub file so processIndex's fileExists check passes. */
 const touchFile = (filePath: string) => fs.writeFile(filePath, "{}");
+
+/** ScanOptions with a no-op patch + no-op report; override per test. Patches are normalized
+ *  from a partial (every phase defaults to an empty handler list). */
+const mkScanOptions = (
+    overrides: { packageIndexMode?: PackageIndexMode; patches?: Partial<Patches>; report?: PatchReportSink } = {},
+): ScanOptions => ({
+    packageIndexMode: overrides.packageIndexMode ?? "use",
+    report: overrides.report ?? (() => {}),
+    patches: {
+        package: overrides.patches?.package ?? [],
+        entry: overrides.patches?.entry ?? [],
+        resource: overrides.patches?.resource ?? [],
+    },
+});
 
 describe("Scanner Module", () => {
     let tempDir: string;
@@ -326,7 +342,7 @@ describe("Scanner Module", () => {
             await fs.writeFile(path.join(packagePath, ".index.json"), JSON.stringify(indexContent));
             await touchFile(path.join(packagePath, "Patient.json"));
 
-            await loadPackage(packagePath, cache, { packageIndexMode: "use", preprocessPackage: (e) => e });
+            await loadPackage(packagePath, cache, mkScanOptions());
 
             // Check package info
             expect(cache.packages["hl7.fhir.test"]).toBeDefined();
@@ -384,7 +400,7 @@ describe("Scanner Module", () => {
             );
             await touchFile(path.join(examplesPath, "example.json"));
 
-            await loadPackage(packagePath, cache, { packageIndexMode: "use", preprocessPackage: (e) => e });
+            await loadPackage(packagePath, cache, mkScanOptions());
 
             expect(cache.entries["http://example.com/Profile"]).toHaveLength(1);
             expect(cache.entries["http://example.com/Patient/example"]).toHaveLength(1);
@@ -395,7 +411,7 @@ describe("Scanner Module", () => {
             const packagePath = path.join(tempDir, "invalid-package");
 
             // Should not throw
-            await loadPackage(packagePath, cache, { packageIndexMode: "use", preprocessPackage: (e) => e });
+            await loadPackage(packagePath, cache, mkScanOptions());
 
             expect(Object.keys(cache.packages)).toHaveLength(0);
         });
@@ -435,7 +451,7 @@ describe("Scanner Module", () => {
             await touchFile(path.join(packagePath, "Ghost.json"));
             await writeResource(path.join(packagePath, "Real.json"), "http://ex/Real");
 
-            await loadPackage(packagePath, cache, { packageIndexMode: "regenerate", preprocessPackage: (e) => e });
+            await loadPackage(packagePath, cache, mkScanOptions({ packageIndexMode: "regenerate" }));
 
             expect(cache.entries["http://ex/Real"]).toHaveLength(1); // scanned from disk
             expect(cache.entries["http://ex/Ghost"]).toBeUndefined(); // shipped index ignored
@@ -464,7 +480,7 @@ describe("Scanner Module", () => {
             );
             await writeResource(path.join(packagePath, "Real.json"), "http://ex/Real");
 
-            await loadPackage(packagePath, cache, { packageIndexMode: "recover", preprocessPackage: (e) => e });
+            await loadPackage(packagePath, cache, mkScanOptions({ packageIndexMode: "recover" }));
 
             expect(cache.entries["http://ex/Real"]).toHaveLength(1); // recovered via scan
             expect(cache.entries["http://ex/Missing"]).toBeUndefined();
@@ -496,7 +512,7 @@ describe("Scanner Module", () => {
             const original = console.warn;
             console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
             try {
-                await loadPackage(packagePath, cache, { packageIndexMode: "use", preprocessPackage: (e) => e });
+                await loadPackage(packagePath, cache, mkScanOptions());
             } finally {
                 console.warn = original;
             }
@@ -517,10 +533,146 @@ describe("Scanner Module", () => {
             );
             await writeResource(path.join(packagePath, "Real.json"), "http://ex/Real");
 
-            await loadPackage(packagePath, cache, { packageIndexMode: "recover", preprocessPackage: (e) => e });
+            await loadPackage(packagePath, cache, mkScanOptions({ packageIndexMode: "recover" }));
 
             // Empty-but-valid index → ok/count:0 → no recover, so the on-disk file is NOT scanned in.
             expect(cache.entries["http://ex/Real"]).toBeUndefined();
+        });
+    });
+
+    describe("loadPackage entry-phase patches", () => {
+        const writePackageJson = (packagePath: string) =>
+            fs.writeFile(
+                path.join(packagePath, "package.json"),
+                JSON.stringify({ name: "test.package", version: "1.0.0" }),
+            );
+        const writeResource = (filePath: string, url: string) =>
+            fs.writeFile(filePath, JSON.stringify({ resourceType: "StructureDefinition", url }));
+
+        test("excludes a canonical via the index path", async () => {
+            const cache = createCacheRecord();
+            const packagePath = path.join(tempDir, "pkg");
+            await fs.mkdir(packagePath, { recursive: true });
+            await writePackageJson(packagePath);
+            await fs.writeFile(
+                path.join(packagePath, ".index.json"),
+                JSON.stringify({
+                    "index-version": 1,
+                    files: [
+                        { filename: "Good.json", resourceType: "StructureDefinition", id: "g", url: "http://ex/Good" },
+                        { filename: "Bad.json", resourceType: "StructureDefinition", id: "b", url: "http://ex/Bad" },
+                    ],
+                }),
+            );
+            await touchFile(path.join(packagePath, "Good.json"));
+            await touchFile(path.join(packagePath, "Bad.json"));
+
+            const entries: ReportEntry[] = [];
+            await loadPackage(
+                packagePath,
+                cache,
+                mkScanOptions({
+                    patches: { entry: [excludeCanonical({ url: "http://ex/Bad", reason: "cross-version" })] },
+                    report: (e) => entries.push(e),
+                }),
+            );
+
+            expect(cache.entries["http://ex/Good"]).toHaveLength(1);
+            expect(cache.entries["http://ex/Bad"]).toBeUndefined();
+            expect(entries.some((e) => e.kind === "exclusion" && e.url === "http://ex/Bad")).toBe(true);
+        });
+
+        test("excludes a canonical via the scan path (regenerate)", async () => {
+            const cache = createCacheRecord();
+            const packagePath = path.join(tempDir, "pkg");
+            await fs.mkdir(packagePath, { recursive: true });
+            await writePackageJson(packagePath);
+            await writeResource(path.join(packagePath, "Good.json"), "http://ex/Good");
+            await writeResource(path.join(packagePath, "Bad.json"), "http://ex/Bad");
+
+            await loadPackage(
+                packagePath,
+                cache,
+                mkScanOptions({
+                    patches: { entry: [excludeCanonical({ url: "http://ex/Bad", reason: "x" })] },
+                    packageIndexMode: "regenerate",
+                }),
+            );
+
+            expect(cache.entries["http://ex/Good"]).toHaveLength(1);
+            expect(cache.entries["http://ex/Bad"]).toBeUndefined();
+        });
+
+        test("commits the transformed entry when a patch returns a new entry context", async () => {
+            const cache = createCacheRecord();
+            const packagePath = path.join(tempDir, "pkg");
+            await fs.mkdir(packagePath, { recursive: true });
+            await writePackageJson(packagePath);
+            await fs.writeFile(
+                path.join(packagePath, ".index.json"),
+                JSON.stringify({
+                    "index-version": 1,
+                    files: [
+                        { filename: "Typo.json", resourceType: "StructureDefinition", id: "t", url: "http://ex/Typo" },
+                    ],
+                }),
+            );
+            await touchFile(path.join(packagePath, "Typo.json"));
+
+            await loadPackage(
+                packagePath,
+                cache,
+                mkScanOptions({
+                    patches: {
+                        entry: [
+                            (_pkg, entry) =>
+                                entry.url === "http://ex/Typo" ? { ...entry, url: "http://ex/Fixed" } : undefined,
+                        ],
+                    },
+                }),
+            );
+
+            // The transformed url is indexed; the original is not.
+            expect(cache.entries["http://ex/Fixed"]).toHaveLength(1);
+            expect(cache.entries["http://ex/Fixed"]?.[0]?.url).toBe("http://ex/Fixed");
+            expect(cache.entries["http://ex/Typo"]).toBeUndefined();
+        });
+
+        test("skips an entry whose url a patch cleared (not registered or indexed)", async () => {
+            const cache = createCacheRecord();
+            const packagePath = path.join(tempDir, "pkg");
+            await fs.mkdir(packagePath, { recursive: true });
+            await writePackageJson(packagePath);
+            await fs.writeFile(
+                path.join(packagePath, ".index.json"),
+                JSON.stringify({
+                    "index-version": 1,
+                    files: [
+                        { filename: "Good.json", resourceType: "StructureDefinition", id: "g", url: "http://ex/Good" },
+                        { filename: "Cl.json", resourceType: "StructureDefinition", id: "c", url: "http://ex/Cleared" },
+                    ],
+                }),
+            );
+            await touchFile(path.join(packagePath, "Good.json"));
+            await touchFile(path.join(packagePath, "Cl.json"));
+
+            await loadPackage(
+                packagePath,
+                cache,
+                mkScanOptions({
+                    patches: {
+                        entry: [
+                            (_pkg, entry) =>
+                                entry.url === "http://ex/Cleared" ? { ...entry, url: undefined } : undefined,
+                        ],
+                    },
+                }),
+            );
+
+            // The url-less entry is neither indexed nor registered; the other is committed.
+            expect(cache.entries["http://ex/Good"]).toHaveLength(1);
+            expect(cache.entries["http://ex/Cleared"]).toBeUndefined();
+            expect(cache.referenceManager.size()).toBe(1);
         });
     });
 
@@ -557,16 +709,15 @@ describe("Scanner Module", () => {
                 }),
             );
 
-            // Hook that fixes the typo
-            const preprocessPackage = (ctx: PreprocessContext): PreprocessContext => {
-                if (ctx.kind !== "package") return ctx;
-                if (ctx.packageJson.name === "test.packge") {
-                    return { ...ctx, packageJson: { ...ctx.packageJson, name: "test.package" } };
-                }
-                return ctx;
+            // Patch that fixes the typo at the package phase
+            const preprocessPackage: Partial<Patches> = {
+                package: [
+                    (_pkg, packageJson) =>
+                        packageJson.name === "test.packge" ? { ...packageJson, name: "test.package" } : undefined,
+                ],
             };
 
-            await loadPackage(packagePath, cache, { packageIndexMode: "use", preprocessPackage });
+            await loadPackage(packagePath, cache, mkScanOptions({ patches: preprocessPackage }));
 
             // Check that cache uses the fixed name
             expect(cache.packages["test.package"]).toBeDefined();
@@ -606,12 +757,11 @@ describe("Scanner Module", () => {
             );
             await touchFile(path.join(packagePath, "Resource.json"));
 
-            const preprocessPackage = (ctx: PreprocessContext): PreprocessContext => {
-                if (ctx.kind !== "package") return ctx;
-                return { ...ctx, packageJson: { ...ctx.packageJson, name: "modified.name" } };
+            const preprocessPackage: Partial<Patches> = {
+                package: [(_pkg, packageJson) => ({ ...packageJson, name: "modified.name" })],
             };
 
-            await loadPackage(packagePath, cache, { packageIndexMode: "use", preprocessPackage });
+            await loadPackage(packagePath, cache, mkScanOptions({ patches: preprocessPackage }));
 
             // Cache should have modified name
             expect(cache.packages["modified.name"]).toBeDefined();
@@ -661,7 +811,7 @@ describe("Scanner Module", () => {
                 JSON.stringify({ name: "regular.package", version: "1.0.0" }),
             );
 
-            await loadPackagesIntoCache(cache, tempDir, { packageIndexMode: "use", preprocessPackage: (e) => e });
+            await loadPackagesIntoCache(cache, tempDir, mkScanOptions());
 
             expect(cache.packages["fhir.package1"]).toBeDefined();
             expect(cache.packages["regular.package"]).toBeDefined(); // All packages are registered now
@@ -696,7 +846,7 @@ describe("Scanner Module", () => {
             );
             await touchFile(path.join(packageDir, "Scoped.json"));
 
-            await loadPackagesIntoCache(cache, tempDir, { packageIndexMode: "use", preprocessPackage: (e) => e });
+            await loadPackagesIntoCache(cache, tempDir, mkScanOptions());
 
             expect(cache.packages["@scope/package"]).toBeDefined();
             expect(cache.entries["http://example.com/Scoped"]).toHaveLength(1);


### PR DESCRIPTION
Adds the composable patch runtime to CanonicalManager — the second half of the Phase 0 foundation for atomic-ehr/codegen#128 (builds on #13's `packageIndex` mode, now merged).

## API
- **`patches?: Patches`** on `Config` — a single object with an optional **list of handlers per phase**:
  ```typescript
  type Patches = {
      package?: PackagePatch[];    // (ctx) => PreprocessPackageContext | undefined
      entry?: EntryPatch[];        // (ctx) => PreprocessEntryContext | null | undefined
      resource?: ResourcePatch[];  // (ctx) => PreprocessResourceContext | undefined
  };
  ```
  Each handler is concretely typed per phase (no `kind` switch, no casts), transforms by returning a same-kind context, no-ops with `undefined`, and **only** an `entry` handler may return `null` to drop the canonical. Handlers within a phase run left-to-right.
- **`excludeCanonical({ url, package?, reason })`** — bundled `EntryPatch` that drops a matching canonical, used as `patches: { entry: [excludeCanonical(...)] }`.
- **`applyPatches(handlers, ctx, report)`** — fold primitive (runs a phase's handler list; entry-phase `null` short-circuits as a drop). Exported with `matchPackage` from the **`@atomic-ehr/fhir-canonical-manager/patch`** subpath.
- **`manager.report(): ReportEntry[]`** — structured record of what CM did (`index-recovery`, `exclusion`, `deprecation`).

```typescript
import { CanonicalManager } from "@atomic-ehr/fhir-canonical-manager";
import { excludeCanonical } from "@atomic-ehr/fhir-canonical-manager/patch";

const manager = CanonicalManager({
    packages: ["hl7.fhir.uv.extensions.r4"],
    workingDir: "./fhir-packages",
    patches: {
        entry: [excludeCanonical({ url: "http://hl7.org/fhir/StructureDefinition/specimen-additive", reason: "Uses CodeableReference, R5-only" })],
    },
});
```

## Behavior
- **Drop** (`null`) is honored **only at the `entry` phase** — applied in both the index and scan paths (`collectFromIndex` / `collectFromDirectory` → `commitEntries`), so an excluded canonical never enters the index regardless of `packageIndex` mode. `null` isn't representable at the package/resource phases (the handler return types forbid it).
- **Transform** is honored at all three phases; entry-phase transforms rewrite the committed index metadata.
- The deprecated `preprocessPackage` hook is preserved and adapted internally to package/resource handlers (entries skipped, kind-guarded) — fully backward compatible.

## Notes
- Exclusions/package transforms are baked into the on-disk cache at index build; changing `patches` between runs needs `dropCache: true` (documented in the README).
- `src/patches/index.ts` was flattened to `src/patches.ts`.

## Tests
- `applyPatches` (order, no-op, entry-phase `null` short-circuit), `excludeCanonical`, `matchPackage`.
- Entry-phase exclusion (index + scan paths) and entry transform; manager-level exclusion absent across `searchEntries`/`resolve` and surfaced in `report()`.
- Legacy `preprocessPackage` (package + resource) behavior unchanged.

All 168 tests pass; typecheck + lint clean. README documents `packageIndex` modes, the `patches` API + `excludeCanonical`, and `report()`.