### PR TITLE
refactor: rename Patches fields to packageJson/indexEntry/fhirResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,13 +341,13 @@ setting both it and `packageIndex` throws.
 
 #### `patches` — composable transforms and exclusions
 
-`patches` is a single `Patches` object with an optional **list of handlers per phase** —
-`package`, `entry`, and `resource`. Each handler receives its package id, the value being
-patched (`packageJson` / `entry` / `resource`), and a diagnostics sink, and returns a
+`patches` is a single `Patches` object with an optional **list of handlers per phase**,
+keyed by the value each handler transforms — `packageJson`, `indexEntry`, and `fhirResource`.
+Each handler receives its package id, that value, and a diagnostics sink, and returns a
 transformed value or `undefined` to no-op; the handlers in a phase run left-to-right. The
-`entry` handlers may also return `null` to **drop** the canonical (it never enters the
+`indexEntry` handlers may also return `null` to **drop** the canonical (it never enters the
 index). Provide only the phases you need; the deprecated `preprocessPackage` is appended
-after your package/resource handlers.
+after your packageJson/fhirResource handlers.
 
 ```typescript
 import type { PackagePatch } from "@atomic-ehr/fhir-canonical-manager";
@@ -356,12 +356,12 @@ import type { PackagePatch } from "@atomic-ehr/fhir-canonical-manager";
 // Fix a package's declared version at the package phase:
 const fixVersion: PackagePatch = (pkg, packageJson) => ({ ...packageJson, version: "1.2.3" });
 
-// patches: { package: [fixVersion] }
+// patches: { packageJson: [fixVersion] }
 ```
 
 The bundled patch helpers (`excludeCanonical`, `applyPatches`, `matchPackage`) are exported
 from the `@atomic-ehr/fhir-canonical-manager/patch` subpath. `excludeCanonical` returns an
-`entry` handler that drops a canonical (e.g. an R4 extension that references an R5-only type):
+`indexEntry` handler that drops a canonical (e.g. an R4 extension that references an R5-only type):
 
 ```typescript
 import { CanonicalManager } from "@atomic-ehr/fhir-canonical-manager";
@@ -371,7 +371,7 @@ const manager = CanonicalManager({
     packages: ["hl7.fhir.uv.extensions.r4"],
     workingDir: "./fhir-packages",
     patches: {
-        entry: [
+        indexEntry: [
             excludeCanonical({
                 url: "http://hl7.org/fhir/StructureDefinition/specimen-additive",
                 reason: "Uses CodeableReference, not available in R4",

--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -75,20 +75,20 @@ const createReportSink = (): { sink: PatchReportSink; entries: ReportEntry[] } =
 const resolveEffectivePatch = (config: Config): Patches => {
     const configured = config.patches ?? {};
     const patches: Patches = {
-        package: [...(configured.package ?? [])],
-        entry: [...(configured.entry ?? [])],
-        resource: [...(configured.resource ?? [])],
+        packageJson: [...(configured.packageJson ?? [])],
+        indexEntry: [...(configured.indexEntry ?? [])],
+        fhirResource: [...(configured.fhirResource ?? [])],
     };
     if (config.preprocessPackage) {
         const legacy = config.preprocessPackage;
         // The legacy hook predates per-phase handlers: it takes a kind-tagged PreprocessContext
         // and only transforms packages/resources. Bridge it — add `kind` going in, strip it (and
-        // guard against a wrong-kind return) coming out — as package/resource handlers.
-        patches.package.push((pkg, packageJson) => {
+        // guard against a wrong-kind return) coming out — as packageJson/fhirResource handlers.
+        patches.packageJson.push((pkg, packageJson) => {
             const r = legacy({ kind: "package", package: pkg, packageJson });
             return r.kind === "package" ? r.packageJson : undefined;
         });
-        patches.resource.push((pkg, resource) => {
+        patches.fhirResource.push((pkg, resource) => {
             const r = legacy({ kind: "resource", package: pkg, resource });
             return r.kind === "resource" ? r.resource : undefined;
         });
@@ -467,7 +467,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
             };
 
             const result = applyPatches(
-                effectivePatches.resource,
+                effectivePatches.fhirResource,
                 { name: metadata.packageName, version: metadata.packageVersion },
                 resource,
                 reportSink,

--- a/src/scanner/package.ts
+++ b/src/scanner/package.ts
@@ -103,7 +103,12 @@ export const loadPackage = async (
     try {
         const content = await fs.readFile(packageJsonPath, "utf-8");
         let parsed = JSON.parse(content);
-        const result = applyPatches(patches.package, { name: parsed.name, version: parsed.version }, parsed, report);
+        const result = applyPatches(
+            patches.packageJson,
+            { name: parsed.name, version: parsed.version },
+            parsed,
+            report,
+        );
         if (result) parsed = result;
         packageJson = parsed as PackageJson;
     } catch {

--- a/src/scanner/processor.ts
+++ b/src/scanner/processor.ts
@@ -141,8 +141,8 @@ export const commitEntries = (
             package: pkg,
         };
 
-        if (patches?.entry.length && report) {
-            const result = applyPatches(patches.entry, pkg, indexEntry, report);
+        if (patches?.indexEntry.length && report) {
+            const result = applyPatches(patches.indexEntry, pkg, indexEntry, report);
             if (result === null) continue; // excluded — never registered or indexed
             indexEntry = result;
         }

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -113,9 +113,9 @@ export type ResourcePatch = (pkg: PackageId, resource: Resource, report: PatchRe
  * phase(s) they care about.
  */
 export type Patches = {
-    package: PackagePatch[];
-    entry: EntryPatch[];
-    resource: ResourcePatch[];
+    packageJson: PackagePatch[];
+    indexEntry: EntryPatch[];
+    fhirResource: ResourcePatch[];
 };
 
 export type PackageManager = "bun" | "npm";

--- a/test/unit/manager/exclusion.test.ts
+++ b/test/unit/manager/exclusion.test.ts
@@ -45,7 +45,7 @@ describe("CM-level exclusion", () => {
         const manager = CanonicalManager({
             packages: [],
             workingDir: path.join(root, "wd"),
-            patches: { entry: [excludeCanonical({ url: "http://ex/Bad", reason: "cross-version type" })] },
+            patches: { indexEntry: [excludeCanonical({ url: "http://ex/Bad", reason: "cross-version type" })] },
         });
         await manager.addLocalPackage({ name: "test.package", version: "1.0.0", path: pkgPath });
         await manager.init();

--- a/test/unit/scanner/scanner.test.ts
+++ b/test/unit/scanner/scanner.test.ts
@@ -26,9 +26,9 @@ const mkScanOptions = (
     packageIndexMode: overrides.packageIndexMode ?? "use",
     report: overrides.report ?? (() => {}),
     patches: {
-        package: overrides.patches?.package ?? [],
-        entry: overrides.patches?.entry ?? [],
-        resource: overrides.patches?.resource ?? [],
+        packageJson: overrides.patches?.packageJson ?? [],
+        indexEntry: overrides.patches?.indexEntry ?? [],
+        fhirResource: overrides.patches?.fhirResource ?? [],
     },
 });
 
@@ -572,7 +572,7 @@ describe("Scanner Module", () => {
                 packagePath,
                 cache,
                 mkScanOptions({
-                    patches: { entry: [excludeCanonical({ url: "http://ex/Bad", reason: "cross-version" })] },
+                    patches: { indexEntry: [excludeCanonical({ url: "http://ex/Bad", reason: "cross-version" })] },
                     report: (e) => entries.push(e),
                 }),
             );
@@ -594,7 +594,7 @@ describe("Scanner Module", () => {
                 packagePath,
                 cache,
                 mkScanOptions({
-                    patches: { entry: [excludeCanonical({ url: "http://ex/Bad", reason: "x" })] },
+                    patches: { indexEntry: [excludeCanonical({ url: "http://ex/Bad", reason: "x" })] },
                     packageIndexMode: "regenerate",
                 }),
             );
@@ -624,7 +624,7 @@ describe("Scanner Module", () => {
                 cache,
                 mkScanOptions({
                     patches: {
-                        entry: [
+                        indexEntry: [
                             (_pkg, entry) =>
                                 entry.url === "http://ex/Typo" ? { ...entry, url: "http://ex/Fixed" } : undefined,
                         ],
@@ -661,7 +661,7 @@ describe("Scanner Module", () => {
                 cache,
                 mkScanOptions({
                     patches: {
-                        entry: [
+                        indexEntry: [
                             (_pkg, entry) =>
                                 entry.url === "http://ex/Cleared" ? { ...entry, url: undefined } : undefined,
                         ],
@@ -711,7 +711,7 @@ describe("Scanner Module", () => {
 
             // Patch that fixes the typo at the package phase
             const preprocessPackage: Partial<Patches> = {
-                package: [
+                packageJson: [
                     (_pkg, packageJson) =>
                         packageJson.name === "test.packge" ? { ...packageJson, name: "test.package" } : undefined,
                 ],
@@ -758,7 +758,7 @@ describe("Scanner Module", () => {
             await touchFile(path.join(packagePath, "Resource.json"));
 
             const preprocessPackage: Partial<Patches> = {
-                package: [(_pkg, packageJson) => ({ ...packageJson, name: "modified.name" })],
+                packageJson: [(_pkg, packageJson) => ({ ...packageJson, name: "modified.name" })],
             };
 
             await loadPackage(packagePath, cache, mkScanOptions({ patches: preprocessPackage }));


### PR DESCRIPTION
Renames the per-phase `Patches` fields to read by **the value each handler transforms** — clearer on the consuming side and no longer echoing the scoping combinators (`forPackage`/`inPackage`, etc.):

| before | after |
|---|---|
| `package` | `packageJson` |
| `entry` | `indexEntry` |
| `resource` | `fhirResource` |

```typescript
export type Patches = {
    packageJson: PackagePatch[];
    indexEntry: EntryPatch[];
    fhirResource: ResourcePatch[];
};
```

Field-only rename — the `PackagePatch`/`EntryPatch`/`ResourcePatch` handler types and their payload argument names are unchanged. Internals (`resolveEffectivePatch`, the legacy `preprocessPackage` adapter, the scanner phases, `read()`), tests, and the README are updated to match.

Verified: typecheck clean, lint clean, 169 tests pass.

## Note
This is a follow-up refinement to the composable-patches API. Once it merges, a fresh canary should be published and codegen repinned (codegen PR #176 then renames its combinators `forPackage`/`forResource` → `inPackage`/`inResource` and uses the new field names).