### PR TITLE
refactor: PackageMatch object form uses PackageId

### DIFF
--- a/src/patches.ts
+++ b/src/patches.ts
@@ -5,7 +5,7 @@
 import type { EntryPatch, IndexEntry, PackageId, PatchReportSink, Resource } from "./types/index.js";
 
 /** Match a package by exact name, name+version, or a predicate. */
-export type PackageMatch = string | { name: string; version?: string } | ((pkg: PackageId) => boolean);
+export type PackageMatch = string | PackageId | ((pkg: PackageId) => boolean);
 
 export const matchPackage = (match: PackageMatch, pkg: PackageId): boolean => {
     if (typeof match === "function") return match(pkg);

--- a/test/unit/patches/patches.test.ts
+++ b/test/unit/patches/patches.test.ts
@@ -75,7 +75,7 @@ describe("matchPackage", () => {
     test("matches by string, object, and predicate", () => {
         expect(matchPackage("p", pkg)).toBe(true);
         expect(matchPackage("q", pkg)).toBe(false);
-        expect(matchPackage({ name: "p" }, pkg)).toBe(true);
+        expect(matchPackage({ name: "p", version: "1" }, pkg)).toBe(true);
         expect(matchPackage({ name: "p", version: "2" }, pkg)).toBe(false);
         expect(matchPackage((x) => x.version === "1", pkg)).toBe(true);
     });


### PR DESCRIPTION
- `PackageMatch` object form now aliases `PackageId` (`{ name; version }`) instead of an inline `{ name: string; version?: string }`.
  - Version is now **required** in the object form; match-by-name-only is expressed with the bare string form (`matchPackage("pkg", ...)`), which already covered that case.
- `matchPackage` runtime is unchanged (the `version === undefined` guard is now defensive/unreachable per the types).
- Updated the `matchPackage` test: the object case now carries an explicit version.