### PR TITLE
refactor: PackageId as type + PackageName/PackageVersion aliases

### DIFF
--- a/src/local.ts
+++ b/src/local.ts
@@ -5,7 +5,7 @@ import { isPathSpec, parsePackageRef } from "./manager/package-spec.js";
 import { installPackages } from "./package.js";
 import type { IndexFile, IndexFileEntry, LocalPackageConfig, PackageId, PackageManager } from "./types/index.js";
 
-const parseDependencySpec = (spec: string): { name: string; version: string } | undefined => {
+const parseDependencySpec = (spec: string): PackageId | undefined => {
     const trimmed = spec.trim();
     if (!trimmed || isPathSpec(trimmed) || trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
         return undefined;

--- a/src/manager/canonical.ts
+++ b/src/manager/canonical.ts
@@ -30,6 +30,7 @@ import type {
     PackageIndexMode,
     PackageInfo,
     PackageJson,
+    PackageName,
     Patches,
     PatchReportSink,
     Reference,
@@ -161,7 +162,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
             }),
         );
     };
-    const localPackageTargetPath = (packageName: string, npmPackagePath: string): string => {
+    const localPackageTargetPath = (packageName: PackageName, npmPackagePath: string): string => {
         const segments = packageName.startsWith("@") ? packageName.split("/") : [packageName];
         return Path.join(npmPackagePath, "node_modules", ...segments);
     };
@@ -606,7 +607,7 @@ export const createCanonicalManager = (config: Config): CanonicalManager => {
         return results;
     };
 
-    const packageJson = async (packageName: string): Promise<PackageJson> => {
+    const packageJson = async (packageName: PackageName): Promise<PackageJson> => {
         ensureInitialized();
         const pkg = cache.packages[packageName];
         if (!pkg) throw new Error(`Package ${packageName} not found`);

--- a/src/package.ts
+++ b/src/package.ts
@@ -8,7 +8,7 @@ import * as afs from "node:fs/promises";
 import * as Path from "node:path";
 import { promisify } from "node:util";
 import { ensureDir, fileExists } from "./fs/index.js";
-import type { PackageManager } from "./types/index.js";
+import type { PackageManager, PackageName } from "./types/index.js";
 
 const execAsync = promisify(exec);
 
@@ -70,7 +70,7 @@ const parsePackageName = (pkg: string): string => {
 /**
  * Get installed package path in node_modules
  */
-const getInstalledPackagePath = (packageName: string, pwd: string): string => {
+const getInstalledPackagePath = (packageName: PackageName, pwd: string): string => {
     const name = parsePackageName(packageName);
     return Path.join(pwd, "node_modules", name);
 };

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -4,14 +4,14 @@
  */
 
 import { createHash } from "node:crypto";
-import type { Reference, ReferenceMetadata, ReferenceStore } from "./types/index.js";
+import type { PackageName, PackageVersion, Reference, ReferenceMetadata, ReferenceStore } from "./types/index.js";
 
 /**
  * Generate a unique reference ID from metadata
  */
 export const generateReferenceId = (metadata: {
-    packageName: string;
-    packageVersion: string;
+    packageName: PackageName;
+    packageVersion: PackageVersion;
     filePath: string;
 }): string => {
     const input = `${metadata.packageName}@${metadata.packageVersion}:${metadata.filePath}`;

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -7,10 +7,13 @@ export interface Reference {
     resourceType: string;
 }
 
-export interface PackageId {
-    name: string;
-    version: string;
-}
+export type PackageName = string;
+export type PackageVersion = string;
+
+export type PackageId = {
+    name: PackageName;
+    version: PackageVersion;
+};
 
 export interface IndexEntry extends Reference {
     indexVersion: number;

--- a/src/types/core.ts
+++ b/src/types/core.ts
@@ -160,9 +160,9 @@ export interface TgzPackageConfig {
 
 export interface LocalPackageConfig {
     /** Package name for the local package */
-    name: string;
+    name: PackageName;
     /** Package version for the local package */
-    version: string;
+    version: PackageVersion;
     /** Absolute path to the local package folder */
     path: string;
     /** Dependencies to install from registry */
@@ -170,8 +170,8 @@ export interface LocalPackageConfig {
 }
 
 export type PackageJson = {
-    name: string;
-    version: string;
+    name: PackageName;
+    version: PackageVersion;
     /** Optional: not all packages declare FHIR version (e.g., hl7.fhir.r4.core lacks it) */
     fhirVersions?: string[];
     type?: string;
@@ -199,7 +199,7 @@ export interface CanonicalManager {
     resolveEntry(
         canonicalUrl: string,
         options?: {
-            package?: string;
+            package?: PackageName;
             version?: string;
             sourceContext?: SourceContext;
         },
@@ -207,7 +207,7 @@ export interface CanonicalManager {
     resolve(
         canonicalUrl: string,
         options?: {
-            package?: string;
+            package?: PackageName;
             version?: string;
             sourceContext?: SourceContext;
         },
@@ -237,7 +237,7 @@ export interface CanonicalManager {
         },
     ): Promise<IndexEntry[]>;
     getSearchParametersForResource(resourceType: string): Promise<SearchParameter[]>;
-    packageJson(packageName: string): Promise<PackageJson>;
+    packageJson(packageName: PackageName): Promise<PackageJson>;
     /**
      * Structured record of defect-handling actions (index recoveries, exclusions, deprecation
      * notices). These are emitted only while **building** the index; on a cached run the actions

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -1,7 +1,7 @@
 /**
  * Internal implementation types for FHIR Canonical Manager
  */
-import type { IndexEntry, PackageInfo } from "./core.js";
+import type { IndexEntry, PackageInfo, PackageName, PackageVersion } from "./core.js";
 
 export interface IndexFile {
     "index-version": number;
@@ -19,8 +19,8 @@ export interface IndexFileEntry {
 }
 
 export interface ReferenceMetadata {
-    packageName: string;
-    packageVersion: string;
+    packageName: PackageName;
+    packageVersion: PackageVersion;
     filePath: string;
     resourceType: string;
     url?: string;


### PR DESCRIPTION
- Convert `PackageId` from `interface` to `type` (it's a closed record shape — no `implements`/merging needed).
- Add `PackageName` and `PackageVersion` as plain `string` aliases; `PackageId` now reads `{ name: PackageName; version: PackageVersion }`.
  - Documentation aliases only — no branding, so they remain assignable to/from `string`.