### PR TITLE
Unify release flow + declare MIT license (fixes #19)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,18 +43,18 @@ jobs:
       - name: Generate canary version
         id: version
         run: |
-          BASE_VERSION=$(node -p "require('./package.json').version")
           COMMIT_SHA=$(git rev-parse --short HEAD)
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
-          CANARY_VERSION="${BASE_VERSION}-canary.${TIMESTAMP}.${COMMIT_SHA}"
-          echo "canary_version=${CANARY_VERSION}" >> $GITHUB_OUTPUT
-          echo "Generated canary version: ${CANARY_VERSION}"
+          CANARY_VERSION_SUFFIX="-canary.${TIMESTAMP}.${COMMIT_SHA}"
+          echo "canary_version_suffix=${CANARY_VERSION_SUFFIX}" >> $GITHUB_OUTPUT
+          echo "Generated canary version suffix: ${CANARY_VERSION_SUFFIX}"
 
       - name: Update package.json version
         run: |
           bun --bun -e "
             const pkg = require('./package.json');
-            pkg.version = '${{ steps.version.outputs.canary_version }}';
+            pkg.version = pkg.version + '${{ steps.version.outputs.canary_version_suffix }}';
+            console.log('Canary version:', pkg.version);
             require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));
           "
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Atomic EHR Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@atomic-ehr/fhir-canonical-manager",
   "version": "0.0.24",
+  "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 set -e
 
-# Check if version argument is provided
-if [ -z "$1" ]; then
-    echo "Error: Version number required"
+# Validate semver format
+if ! echo "$1" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+    echo "❌ Error: Invalid version format"
     echo "Usage: bun run release <version>"
     echo "Example: bun run release 0.0.18"
     exit 1
 fi
+
+VERSION=$1
 
 # Check if we're on main branch
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -18,7 +20,12 @@ if [ "$CURRENT_BRANCH" != "main" ]; then
     exit 1
 fi
 
-VERSION=$1
+# Check for uncommitted changes
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "❌ Error: Working tree has uncommitted changes"
+    echo "Please commit or stash your changes before releasing"
+    exit 1
+fi
 
 echo "📦 Releasing version $VERSION..."
 


### PR DESCRIPTION
## Summary

Two related changes, keeping this repo's release flow consistent with the `@atomic-ehr/codegen` standard.

### 1. Unify release flow
- **`scripts/release.sh`**: backport the two guardrails codegen already has:
  - **semver-format validation** — rejects typos like `0.025` before a bad tag is created/published
  - **clean-tree check** — refuses to release with uncommitted changes
  - Retained the `package-lock.json` handling (this repo tracks one, unlike codegen).
- **Workflow**: renamed `canary.yml` → `release.yml` (matches codegen/fhirschema) and aligned the canary-version step with the shared suffix style. Per-repo test steps (`bun test` + `typecheck`) and the non-draft GitHub Release are unchanged.

### 2. Declare MIT license — fixes #19
- Added a root `LICENSE` (MIT, matching `@atomic-ehr/codegen` and `@atomic-ehr/fhirschema`).
- Added `"license": "MIT"` to `package.json`.

After merge, cut the patch release with `bun run release 0.0.25` so the metadata reaches npm.

Companion PR aligns `fhirschema`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)